### PR TITLE
7.0 : Add module hr_expense_sequence

### DIFF
--- a/hr_expense_sequence/__init__.py
+++ b/hr_expense_sequence/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    HR Expense Sequence module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import hr_expense_sequence

--- a/hr_expense_sequence/__openerp__.py
+++ b/hr_expense_sequence/__openerp__.py
@@ -1,0 +1,48 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    HR Expense Sequence module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Sequence on Expenses',
+    'version': '0.1',
+    'category': 'Human Resources',
+    'license': 'AGPL-3',
+    'summary': "Adds a sequence on expenses",
+    'description': """
+Sequence on Expenses
+====================
+
+This module adds a sequence on expenses. This sequence is also used as
+reference in the related account move.
+
+This module has been written by Alexis de Lattre
+<alexis.delattre@akretion.com>.
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com',
+    'depends': ['hr_expense'],
+    'data': [
+        'hr_expense_view.xml',
+        'hr_expense_sequence.xml',
+    ],
+    'demo': ['hr_expense_demo.xml'],
+    'installable': True,
+}

--- a/hr_expense_sequence/hr_expense_demo.xml
+++ b/hr_expense_sequence/hr_expense_demo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2014 Akretion (http://www.akretion.com)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data noupdate="1">
+
+<record id="hr_expense.sep_expenses" model="hr.expense.expense">
+    <field name="name">EXP0001</field>
+    <field name="description">September Expenses</field>
+</record>
+
+<record id="hr_expense.expenses0" model="hr.expense.expense">
+    <field name="name">EXP0002</field>
+    <field name="description">Expenses</field>
+</record>
+
+<record id="hr_expense_seq" model="ir.sequence">
+    <field name="number_next">3</field>
+</record>
+
+</data>
+</openerp>

--- a/hr_expense_sequence/hr_expense_sequence.py
+++ b/hr_expense_sequence/hr_expense_sequence.py
@@ -1,0 +1,61 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    HR Expense Sequence module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from openerp.tools.translate import _
+
+
+class hr_expense_expense(orm.Model):
+    _inherit = 'hr.expense.expense'
+    _order = 'name desc'
+
+    _columns = {
+        # Move the description from the 'name' field to 'description' field
+        # In the 'name' field, we now store the number/sequence
+        'name': fields.char('Number', size=32, readonly=True),
+        'description': fields.char(
+            'Description', size=128, required=True, readonly=True,
+            states={
+                'draft': [('readonly', False)],
+                'confirm': [('readonly', False)],
+            }),
+        }
+
+    _defaults = {
+        'name': '/',
+        }
+
+    def copy(self, cr, uid, id, default=None, context=None):
+        if default is None:
+            default = {}
+        default['name'] = '/'
+        expense = self.browse(cr, uid, id, context=context)
+        default['description'] = _("%s (copy)") % (expense.description or '')
+        return super(hr_expense_expense, self).copy(
+            cr, uid, id, default=default, context=context)
+
+    def create(self, cr, uid, vals, context=None):
+        if vals.get('name', '/') == '/':
+            vals['name'] = self.pool['ir.sequence'].next_by_code(
+                cr, uid, 'hr.expense.expense', context=context)
+        return super(hr_expense_expense, self).create(
+            cr, uid, vals, context=context)

--- a/hr_expense_sequence/hr_expense_sequence.py
+++ b/hr_expense_sequence/hr_expense_sequence.py
@@ -44,6 +44,11 @@ class hr_expense_expense(orm.Model):
         'name': '/',
         }
 
+    _sql_constraints = [(
+        'company_name_uniq',
+        'unique(company_id, name)',
+        'An expense with that number already exists in the same company !')]
+
     def copy(self, cr, uid, id, default=None, context=None):
         if default is None:
             default = {}

--- a/hr_expense_sequence/hr_expense_sequence.xml
+++ b/hr_expense_sequence/hr_expense_sequence.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2014 Akretion (http://www.akretion.com)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data noupdate="1">
+
+<!--
+In the module hr_expense of the official addons, there is a sequence
+'hr.expense.invoice' defined in addons/hr_expense/hr_expense_sequence.xml
+but this sequence is not used in the code since OpenERP 7.0, so it will
+probably be dropped silently in a future version. That's why I prefer to
+define my own sequence in this module with a more suitable name
+'hr.expense.expense'.
+-->
+
+<record id="hr_expense_seq_type" model="ir.sequence.type">
+    <field name="name">HR Expense</field>
+    <field name="code">hr.expense.expense</field>
+</record>
+
+<record id="hr_expense_seq" model="ir.sequence">
+    <field name="name">HR Expense</field>
+    <field name="code">hr.expense.expense</field>
+    <field name="prefix">EXP</field>
+    <field name="padding">4</field>
+</record>
+
+</data>
+</openerp>

--- a/hr_expense_sequence/hr_expense_view.xml
+++ b/hr_expense_sequence/hr_expense_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2014 Akretion (http://www.akretion.com)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  The licence is in the file __openerp__.py
+-->
+<openerp>
+<data>
+
+<record id="view_expenses_form" model="ir.ui.view">
+    <field name="name">expense.sequence.expense.form</field>
+    <field name="model">hr.expense.expense</field>
+    <field name="inherit_id" ref="hr_expense.view_expenses_form"/>
+    <field name="arch" type="xml">
+        <field name="name" position="after">
+            <field name="description"/>
+        </field>
+    </field>
+</record>
+
+<record id="view_expenses_tree" model="ir.ui.view">
+    <field name="name">expense.sequence.expense.tree</field>
+    <field name="model">hr.expense.expense</field>
+    <field name="inherit_id" ref="hr_expense.view_expenses_tree"/>
+    <field name="arch" type="xml">
+        <field name="name" position="after">
+            <field name="description"/>
+        </field>
+    </field>
+</record>
+
+</data>
+</openerp>

--- a/hr_expense_sequence/i18n/fr.po
+++ b/hr_expense_sequence/i18n/fr.po
@@ -1,0 +1,27 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* hr_expense_sequence
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-11 23:42+0000\n"
+"PO-Revision-Date: 2014-08-11 23:42+0000\n"
+"Last-Translator: Alexis de Lattre <alexis.delattre@akretion.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_expense_sequence
+#: field:hr.expense.expense,description:0
+msgid "Description"
+msgstr "Description"
+
+#. module: hr_expense_sequence
+#: model:ir.model,name:hr_expense_sequence.model_hr_expense_expense
+msgid "Expense"
+msgstr "Frais"
+

--- a/hr_expense_sequence/i18n/hr_expense_sequence.pot
+++ b/hr_expense_sequence/i18n/hr_expense_sequence.pot
@@ -1,0 +1,27 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* hr_expense_sequence
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-11 23:41+0000\n"
+"PO-Revision-Date: 2014-08-11 23:41+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_expense_sequence
+#: field:hr.expense.expense,description:0
+msgid "Description"
+msgstr ""
+
+#. module: hr_expense_sequence
+#: model:ir.model,name:hr_expense_sequence.model_hr_expense_expense
+msgid "Expense"
+msgstr ""
+


### PR DESCRIPTION
This module puts a sequence in the 'name' field of hr.expense.expense and adds a 'description' field to replace it. That way, the expense number is used in the ref of the account.move.
