### PR TITLE
7.0 Add module hr_expense_analytic_default

### DIFF
--- a/hr_expense_analytic_default/__init__.py
+++ b/hr_expense_analytic_default/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    HR Expense Analytic Default module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import expense_analytic_default

--- a/hr_expense_analytic_default/__openerp__.py
+++ b/hr_expense_analytic_default/__openerp__.py
@@ -1,0 +1,57 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    HR Expense Analytic Default module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    'name': 'Default Analytic on Expenses',
+    'version': '0.1',
+    'category': 'Human Resources',
+    'license': 'AGPL-3',
+    'summary': "Manage default analytic account on expenses",
+    'description': """
+Default Analytic on Expenses
+===========================
+
+This module adds 2 fields:
+
+* *Default Analytic Account* on the employee form (*HR Settings* tab),
+
+* *Default Analytic Account* on the expense form.
+
+If you set a Default Analytic Account on the employee, it will be copied
+to the Default Analytic Account of the expenses of this employee. The
+Default Analytic Account of the expense is used by default on each
+expense line.
+
+This module has been written by Alexis de Lattre
+<alexis.delattre@akretion.com>.
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com',
+    'depends': ['hr_expense'],
+    'data': [
+        'hr_employee_view.xml',
+        'hr_expense_view.xml',
+    ],
+    'demo': ['expense_analytic_default_demo.xml'],
+    'installable': True,
+}

--- a/hr_expense_analytic_default/expense_analytic_default.py
+++ b/hr_expense_analytic_default/expense_analytic_default.py
@@ -1,0 +1,57 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    HR Expense Analytic Default module for OpenERP
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class hr_employee(orm.Model):
+    _inherit = 'hr.employee'
+
+    _columns = {
+        'default_analytic_account_id': fields.many2one(
+            'account.analytic.account', 'Default Analytic Account',
+            domain=[('type', 'not in', ('view', 'template'))],
+            help="This field will be copied on the expenses of this employee."
+            ),
+        }
+
+
+class hr_expense_expense(orm.Model):
+    _inherit = 'hr.expense.expense'
+
+    _columns = {
+        'default_analytic_account_id': fields.many2one(
+            'account.analytic.account', 'Default Analytic Account',
+            domain=[('type', 'not in', ('view', 'template'))]),
+        }
+
+    def onchange_employee_id(self, cr, uid, ids, employee_id, context=None):
+        res = super(hr_expense_expense, self).onchange_employee_id(
+            cr, uid, ids, employee_id, context=context)
+        analytic_account_id = False
+        if employee_id:
+            employee = self.pool['hr.employee'].browse(
+                cr, uid, employee_id, context=context)
+            analytic_account_id = \
+                employee.default_analytic_account_id.id or False
+        res['value']['default_analytic_account_id'] = analytic_account_id
+        return res

--- a/hr_expense_analytic_default/expense_analytic_default_demo.xml
+++ b/hr_expense_analytic_default/expense_analytic_default_demo.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2014 Akretion (http://www.akretion.com)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data noupdate="1">
+
+<record id="hr.employee_fp" model="hr.employee">
+    <field name="default_analytic_account_id" ref="account.analytic_administratif"/>
+</record>
+
+<record id="hr.employee_mit" model="hr.employee">
+    <field name="default_analytic_account_id" ref="account.analytic_trunk"/>
+</record>
+
+<record id="hr.employee_al" model="hr.employee">
+    <field name="default_analytic_account_id" ref="account.analytic_trunk"/>
+</record>
+
+<record id="hr_expense.sep_expenses" model="hr.expense.expense">
+    <field name="default_analytic_account_id" ref="account.analytic_nebula"/>
+</record>
+
+<record id="hr_expense.expenses0" model="hr.expense.expense">
+    <field name="default_analytic_account_id" ref="account.analytic_consultancy"/>
+</record>
+
+
+</data>
+</openerp>

--- a/hr_expense_analytic_default/hr_employee_view.xml
+++ b/hr_expense_analytic_default/hr_employee_view.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2014 Akretion (http://www.akretion.com)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  The licence is in the file __openerp__.py
+-->
+<openerp>
+<data>
+
+<record id="view_employee_form" model="ir.ui.view">
+    <field name="name">expense.analytic.default.employee.form</field>
+    <field name="model">hr.employee</field>
+    <field name="inherit_id" ref="hr.view_employee_form"/>
+    <field name="arch" type="xml">
+        <page string="HR Settings" position="inside">
+            <group name="expense-analytic" string="Analytic on Expenses">
+                <field name="default_analytic_account_id"/>
+            </group>
+        </page>
+    </field>
+</record>
+
+
+</data>
+</openerp>

--- a/hr_expense_analytic_default/hr_expense_view.xml
+++ b/hr_expense_analytic_default/hr_expense_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2014 Akretion (http://www.akretion.com)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  The licence is in the file __openerp__.py
+-->
+<openerp>
+<data>
+
+<record id="view_expenses_form" model="ir.ui.view">
+    <field name="name">expense.analytic.default.expense.form</field>
+    <field name="model">hr.expense.expense</field>
+    <field name="inherit_id" ref="hr_expense.view_expenses_form"/>
+    <field name="arch" type="xml">
+        <field name="department_id" position="after">
+            <field name="default_analytic_account_id"/>
+        </field>
+        <xpath expr="//field[@name='line_ids']" position="attributes">
+            <attribute name="context">{'currency_id': currency_id, 'default_analytic_account': default_analytic_account_id or context.get('analytic_account')}</attribute>
+        </xpath>
+    </field>
+</record>
+
+
+</data>
+</openerp>

--- a/hr_expense_analytic_default/i18n/fr.po
+++ b/hr_expense_analytic_default/i18n/fr.po
@@ -1,0 +1,53 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* hr_expense_analytic_default
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-11 18:51+0000\n"
+"PO-Revision-Date: 2014-08-11 18:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_expense_analytic_default
+#: view:hr.employee:0
+msgid "Analytic on Expenses"
+msgstr "Analytique sur les notes de frais"
+
+#. module: hr_expense_analytic_default
+#: field:hr.employee,default_analytic_account_id:0
+#: field:hr.expense.expense,default_analytic_account_id:0
+msgid "Default Analytic Account"
+msgstr "Compte analytique par défaut"
+
+#. module: hr_expense_analytic_default
+#: model:ir.model,name:hr_expense_analytic_default.model_hr_employee
+msgid "Employee"
+msgstr "Employé"
+
+#. module: hr_expense_analytic_default
+#: model:ir.model,name:hr_expense_analytic_default.model_hr_expense_expense
+msgid "Expense"
+msgstr "Frais"
+
+#. module: hr_expense_analytic_default
+#: view:hr.employee:0
+msgid "HR Settings"
+msgstr "Paramètres RH"
+
+#. module: hr_expense_analytic_default
+#: help:hr.employee,default_analytic_account_id:0
+msgid "This field will be copied on the expenses of this employee."
+msgstr "Ce champ sera copié sur les notes de frais de cet employé."
+
+#. module: hr_expense_analytic_default
+#: view:hr.expense.expense:0
+msgid "{'currency_id': currency_id, 'default_analytic_account': default_analytic_account_id or context.get('analytic_account')}"
+msgstr "{'currency_id': currency_id, 'default_analytic_account': default_analytic_account_id or context.get('analytic_account')}"
+

--- a/hr_expense_analytic_default/i18n/hr_expense_analytic_default.pot
+++ b/hr_expense_analytic_default/i18n/hr_expense_analytic_default.pot
@@ -1,0 +1,53 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* hr_expense_analytic_default
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-11 18:50+0000\n"
+"PO-Revision-Date: 2014-08-11 18:50+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_expense_analytic_default
+#: view:hr.employee:0
+msgid "Analytic on Expenses"
+msgstr ""
+
+#. module: hr_expense_analytic_default
+#: field:hr.employee,default_analytic_account_id:0
+#: field:hr.expense.expense,default_analytic_account_id:0
+msgid "Default Analytic Account"
+msgstr ""
+
+#. module: hr_expense_analytic_default
+#: model:ir.model,name:hr_expense_analytic_default.model_hr_employee
+msgid "Employee"
+msgstr ""
+
+#. module: hr_expense_analytic_default
+#: model:ir.model,name:hr_expense_analytic_default.model_hr_expense_expense
+msgid "Expense"
+msgstr ""
+
+#. module: hr_expense_analytic_default
+#: view:hr.employee:0
+msgid "HR Settings"
+msgstr ""
+
+#. module: hr_expense_analytic_default
+#: help:hr.employee,default_analytic_account_id:0
+msgid "This field will be copied on the expenses of this employee."
+msgstr ""
+
+#. module: hr_expense_analytic_default
+#: view:hr.expense.expense:0
+msgid "{'currency_id': currency_id, 'default_analytic_account': default_analytic_account_id or context.get('analytic_account')}"
+msgstr ""
+


### PR DESCRIPTION
Extract from the module description:

This module adds 2 fields:

1) Default Analytic Account on the employee form,

2) Default Analytic Account on the expense form.

If you set a Default Analytic Account on the employee, it will be copied
to the Default Analytic Account of the expenses of this employee. The
Default Analytic Account of the expense is used by default on each
expense line.

It is very useful when you use analytic per "sector" of the company (R&D, Sales, Marketing, etc...) ; in this case, it is easy to assign a default analytic account for each employee and it will be easier for this employee to have the analytic account of his sector set by default on his expense and expense lines.
