### PR TITLE
activate translation for public holiday name

### DIFF
--- a/hr_public_holidays/hr_public_holidays.py
+++ b/hr_public_holidays/hr_public_holidays.py
@@ -145,7 +145,7 @@ class hr_holidays_line(osv.osv):
     _description = 'Public Holidays Lines'
 
     _columns = {
-        'name': fields.char('Name', size=128, required=True),
+        'name': fields.char('Name', size=128, required=True, translate=True),
         'date': fields.date('Date', required=True),
         'holidays_id': fields.many2one('hr.holidays.public',
                                        'Holiday Calendar Year'),


### PR DESCRIPTION
We just add the translate attribute for the name of holiday to true to support multi language.
