### PR TITLE
7.0: make runbot build green

### DIFF
--- a/hr_contract_reference/hr_contract_view.xml
+++ b/hr_contract_reference/hr_contract_view.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-        
+
         <record id="hr_contract_view" model="ir.ui.view">
             <field name="name">hr.contract.form.view.inherit.ref</field>
             <field name="model">hr.contract</field>
-            <field name="type">form</field>
             <field name="inherit_id" ref="hr_contract.hr_contract_view_form"/>
             <field name="arch" type="xml">
                 <field name="name" position="replace">

--- a/hr_contract_state/hr_contract.py
+++ b/hr_contract_state/hr_contract.py
@@ -20,6 +20,7 @@
 #
 
 import time
+import logging
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
@@ -27,6 +28,8 @@ from dateutil.relativedelta import relativedelta
 from openerp import netsvc
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
 from openerp.osv import fields, orm
+
+_l = logging.getLogger(__name__)
 
 
 class hr_contract(orm.Model):
@@ -155,9 +158,7 @@ class hr_contract(orm.Model):
 
     def onchange_job(self, cr, uid, ids, job_id, context=None):
 
-        import logging
-        _l = logging.getLogger(__name__)
-        _l.warning('hr_contract_state: onchange_job()')
+        _l.debug('hr_contract_state: onchange_job()')
         res = False
         if isinstance(ids, (int, long)):
             ids = [ids]

--- a/hr_emergency_contact/emergency_contact_view.xml
+++ b/hr_emergency_contact/emergency_contact_view.xml
@@ -23,17 +23,16 @@
 
 <openerp>
     <data>
-        
+
         <record id="emergency_contact_view_form" model="ir.ui.view">
             <field name="name">hr.emergency_contact.form</field>
             <field name="model">hr.emergency_contact</field>
-            <field name="type">form</field>
             <field name="arch" type="xml">
                 <form string="Emergency Contact">
                 </form>
             </field>
         </record>
-        
+
         <record id="hr_employee_view_form" model="ir.ui.view">
             <field name="name">hr.employee.view.form.inherit</field>
             <field name="model">hr.employee</field>
@@ -57,6 +56,6 @@
                 </xpath>
             </field>
         </record>
-        
+
     </data>
 </openerp>

--- a/hr_employee_exemption/models/hr_employee.py
+++ b/hr_employee_exemption/models/hr_employee.py
@@ -45,7 +45,7 @@ class HrEmployee(orm.Model):
         if isinstance(ids, (int, long)):
             ids = [ids]
 
-        assert(len(ids), 1)
+        assert len(ids) == 1, 'must be called with a single employee'
 
         employee = self.browse(cr, uid, ids[0], context=context)
 

--- a/hr_employee_exemption/models/hr_salary_rule.py
+++ b/hr_employee_exemption/models/hr_salary_rule.py
@@ -46,7 +46,7 @@ class HrSalaryRule(orm.Model):
         if isinstance(ids, (int, long)):
             ids = [ids]
 
-        assert(len(ids), 1)
+        assert len(ids) == 1, 'must be called with a single employee'
 
         rule = self.browse(cr, uid, ids[0], context=context)
 

--- a/hr_employee_firstname/hr.py
+++ b/hr_employee_firstname/hr.py
@@ -26,17 +26,20 @@ from openerp.osv import orm, fields
 class hr_employee(orm.Model):
     _inherit = 'hr.employee'
 
-    def init(self, cursor):
-        cursor.execute('''\
-SELECT id
-FROM hr_employee
-WHERE lastname IS NOT NULL
-LIMIT 1''')
-        if not cursor.fetchone():
-            cursor.execute('''\
-UPDATE hr_employee
-SET lastname = name_related
-WHERE name_related IS NOT NULL''')
+    def _auto_init(self, cr, context=None):
+        """pre-create and fill column lastname so that the constraint
+        setting will not fail"""
+        self._field_create(cr, context=context)
+        column_data = self._select_column_data(cr)
+        if 'lastname' not in column_data:
+            field = self._columns['lastname']
+            cr.execute('ALTER TABLE "%s" ADD COLUMN "lastname" %s' %
+                       (self._table,
+                        orm.pg_varchar(field.size)))
+            cr.execute('UPDATE hr_employee '
+                       'SET lastname = name_related '
+                       'WHERE name_related IS NOT NULL')
+        return super(hr_employee, self)._auto_init(cr, context=context)
 
     def create(self, cursor, uid, vals, context=None):
         firstname = vals.get('firstname')

--- a/hr_employee_id/hr_contract_view.xml
+++ b/hr_employee_id/hr_contract_view.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-        
+
         <record id="hr_contract_view" model="ir.ui.view">
             <field name="name">hr.contract.form.view.inherit.ref</field>
             <field name="model">hr.contract</field>
-            <field name="type">form</field>
             <field name="inherit_id" ref="hr_contract.hr_contract_view_form"/>
             <field name="arch" type="xml">
                 <field name="name" position="replace">

--- a/hr_experience/hr_certification_view.xml
+++ b/hr_experience/hr_certification_view.xml
@@ -4,7 +4,6 @@
     <record model="ir.ui.view" id="view_certification_tree">
       <field name="name">hr.certification.tree</field>
       <field name="model">hr.certification</field>
-      <field name="type">tree</field>
       <field name="arch" type="xml">
         <tree string="certifications">
           <field name="name"/>
@@ -19,7 +18,6 @@
     <record model="ir.ui.view" id="view_certification_form">
       <field name="name">hr.certification.form</field>
       <field name="model">hr.certification</field>
-      <field name="type">form</field>
       <field name="arch" type="xml">
         <form string="certification">
           <field name="name"/>

--- a/hr_experience/hr_employee_view.xml
+++ b/hr_experience/hr_employee_view.xml
@@ -5,7 +5,6 @@
       <field name="name">hr.experience.employee.form</field>
       <field name="model">hr.employee</field>
       <field name="inherit_id" ref="hr.view_employee_form"/>
-      <field name="type">form</field>
       <field name="arch" type="xml">
         <notebook position="inside">
           <page string="Academic">

--- a/hr_experience/hr_professional_view.xml
+++ b/hr_experience/hr_professional_view.xml
@@ -4,7 +4,6 @@
     <record model="ir.ui.view" id="view_professional_tree">
       <field name="name">hr.experience.tree</field>
       <field name="model">hr.experience</field>
-      <field name="type">tree</field>
       <field name="arch" type="xml">
         <tree string="Professional Experiences">
           <field name="name"/>
@@ -19,7 +18,6 @@
     <record model="ir.ui.view" id="view_professional_form">
       <field name="name">hr.experience.form</field>
       <field name="model">hr.experience</field>
-      <field name="type">form</field>
       <field name="arch" type="xml">
         <form string="Professional Experience">
           <field name="name"/>

--- a/hr_family/hr_view.xml
+++ b/hr_family/hr_view.xml
@@ -23,7 +23,7 @@
 
 <openerp>
     <data>
-        
+
         <record id="hr_employee_view_form" model="ir.ui.view">
             <field name="name">hr.employee.view.form.inherit.familyinfo</field>
             <field name="model">hr.employee</field>
@@ -35,7 +35,7 @@
                             <group string="Spouse">
                                 <field name="fam_spouse"/>
                                 <field name="fam_spouse_employer"/>
-                                <field name="fam_spouse_tel"/>                            
+                                <field name="fam_spouse_tel"/>
                             </group>
                             <group string="Parents">
                                 <field name="fam_father"/>
@@ -51,11 +51,10 @@
                 </xpath>
             </field>
         </record>
-        
+
         <record id="hr_children_view_tree" model="ir.ui.view">
             <field name="name">hr.children.view.tree</field>
             <field name="model">hr.employee.children</field>
-            <field name="type">tree</field>
             <field name="arch" type="xml">
                 <tree string="Employee Children">
                     <field name="name"/>
@@ -66,7 +65,6 @@
         <record id="hr_children_view_form" model="ir.ui.view">
             <field name="name">hr.children.view.form</field>
             <field name="model">hr.employee.children</field>
-            <field name="type">form</field>
             <field name="arch" type="xml">
                 <form string="Employee Children">
                     <field name="name"/>
@@ -74,6 +72,6 @@
                 </form>
             </field>
         </record>
-        
+
     </data>
 </openerp>

--- a/hr_holidays_extension/hr_holidays.py
+++ b/hr_holidays_extension/hr_holidays.py
@@ -21,6 +21,7 @@
 #
 #
 
+import logging
 from datetime import datetime, timedelta
 from pytz import timezone, utc
 
@@ -28,6 +29,8 @@ from openerp.osv import fields, orm
 from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT as OE_DTFORMAT
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT as OE_DFORMAT
 from openerp.tools.translate import _
+
+_l = logging.getLogger(__name__)
 
 
 class hr_holidays_status(orm.Model):
@@ -79,9 +82,7 @@ class hr_holidays(orm.Model):
 
         # If the user didn't enter from "My Leaves" don't pre-populate Employee
         # field
-        import logging
-        _l = logging.getLogger(__name__)
-        _l.warning('context: %s', context)
+        _l.debug('context: %s', context)
         if not context.get('search_default_my_leaves', False):
             return False
 

--- a/hr_job_categories/hr.py
+++ b/hr_job_categories/hr.py
@@ -52,7 +52,7 @@ class hr_contract(orm.Model):
             cr, uid, employee_id, ['category_ids'], context=context
         )
         job = self.pool.get('hr.job').browse(cr, uid, job_id, context=context)
-        _l.warning('remv: eedata: %s', eedata)
+        _l.debug('remv: eedata: %s', eedata)
         for tag in job.category_ids:
             if tag.id in eedata['category_ids']:
                 ee_obj.write(
@@ -71,11 +71,11 @@ class hr_contract(orm.Model):
             cr, uid, employee_id, ['category_ids'], context=context
         )
         job = self.pool.get('hr.job').browse(cr, uid, job_id, context=context)
-        _l.warning('tag: eedata: %s', eedata)
+        _l.debug('tag: eedata: %s', eedata)
         for tag in job.category_ids:
-            _l.warning('tag: name,id: %s,%s', tag.name, tag.id)
+            _l.debug('tag: name,id: %s,%s', tag.name, tag.id)
             if tag.id not in eedata['category_ids']:
-                _l.warning('tag: write()')
+                _l.debug('tag: write()')
                 ee_obj.write(
                     cr, uid, employee_id, {
                         'category_ids': [(4, tag.id)],
@@ -97,7 +97,7 @@ class hr_contract(orm.Model):
             ids = [ids]
 
         prev_data = self.read(cr, uid, ids, ['job_id'], context=context)
-        _l.warning('prev_data: %s', prev_data)
+        _l.debug('prev_data: %s', prev_data)
 
         res = super(hr_contract, self).write(
             cr, uid, ids, vals, context=context)
@@ -115,7 +115,7 @@ class hr_contract(orm.Model):
                         prev_job_id = data['job_id'][0]
                     else:
                         prev_job_id = False
-                    _l.warning(
+                    _l.debug(
                         'prev Job, new job: %s, %s',
                         prev_job_id, vals.get('job_id', False)
                     )

--- a/hr_language/hr_language_view.xml
+++ b/hr_language/hr_language_view.xml
@@ -5,7 +5,6 @@
         <field name="name">hr.language.employee.form</field>
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
-        <field name="type">form</field>
         <field name="arch" type="xml">
             <notebook position="inside">
                 <page string="Languages">
@@ -20,7 +19,6 @@
     <record model="ir.ui.view" id="view_language_tree">
         <field name="name">hr.language.tree</field>
         <field name="model">hr.language</field>
-        <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree string="Languages">
                 <field name="description"/>
@@ -34,7 +32,6 @@
     <record model="ir.ui.view" id="view_language_form">
         <field name="name">hr.language.form</field>
         <field name="model">hr.language</field>
-        <field name="type">form</field>
         <field name="arch" type="xml">
             <form string="Language">
                 <field name="name"/>

--- a/hr_leave_accruals/res_company.py
+++ b/hr_leave_accruals/res_company.py
@@ -32,6 +32,6 @@ class res_company(orm.Model):
         ),
     }
 
-    _default = {
+    _defaults = {
         'holidays_hours_per_day': 8.0,
     }

--- a/hr_payroll_extension/hr_payroll.py
+++ b/hr_payroll_extension/hr_payroll.py
@@ -835,8 +835,8 @@ class hr_payslip(orm.Model):
                                     'number_of_hours'] += normal_hours
                                 attendances[line.code]['number_of_days'] += 1.0
                                 done = True
-                                _l.warning('nh: %s', normal_hours)
-                                _l.warning('att: %s', attendances[line.code])
+                                _l.debug('nh: %s', normal_hours)
+                                _l.debug('att: %s', attendances[line.code])
 
                     if push_lsd:
                         lsd.push(True)

--- a/hr_payroll_period/data/hr_payroll_period_data.xml
+++ b/hr_payroll_period/data/hr_payroll_period_data.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data noupdate="1">
-        
+      <record id="default_payroll_period_schedule"
+              model="hr.payroll.period.schedule">
+        <field name="name">Payroll Period Schedule</field>
+        <field name="tz">UTC</field>
+        <field name="type">manual</field>
+      </record>
         <!-- Messaging / Chatter -->
         
         <record id="mt_state_open" model="mail.message.subtype">

--- a/hr_payroll_period/hr_payroll_period.py
+++ b/hr_payroll_period/hr_payroll_period.py
@@ -865,6 +865,21 @@ class hr_holidays_status(orm.Model):
     _name = 'hr.holidays.status'
     _inherit = 'hr.holidays.status'
 
+    def _auto_init(self, cr, context=None):
+        """pre-create and fill column code so that the constraint
+        setting will not fail"""
+        self._field_create(cr, context=context)
+        column_data = self._select_column_data(cr)
+        if 'code' not in column_data:
+            field = self._columns['code']
+            cr.execute('ALTER TABLE "%s" ADD COLUMN "code" %s' %
+                       (self._table,
+                        orm.pg_varchar(field.size)))
+            cr.execute('UPDATE hr_holidays_status '
+                       'SET code = substring(name from 1 for 16) '
+                       'WHERE code IS NULL')
+        return super(hr_holidays_status, self)._auto_init(cr, context=context)
+
     _columns = {
         'code': fields.char('Code', size=16, required=True),
     }

--- a/hr_payroll_register/wizard/hr_payroll_register_run_view.xml
+++ b/hr_payroll_register/wizard/hr_payroll_register_run_view.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data>
-        
+
         <record id="view_payroll_register" model="ir.ui.view">
             <field name="name">hr.payroll.register.run.wizard</field>
             <field name="model">hr.payroll.register.run</field>
-            <field name="type">form</field>
             <field name="arch" type="xml">
                 <form string="Payslip Creation by Department">
                     <group colspan="4" >

--- a/hr_resume/hr_resume_view.xml
+++ b/hr_resume/hr_resume_view.xml
@@ -5,7 +5,6 @@
         <field name="name">hr.resume.employee.form</field>
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
-        <field name="type">form</field>
         <field name="arch" type="xml">
             <notebook position="inside">
                 <page string="Biography">

--- a/hr_schedule/data/hr_schedule_data.xml
+++ b/hr_schedule/data/hr_schedule_data.xml
@@ -36,6 +36,9 @@
             <field name="name">Sunday</field>
             <field name="sequence" eval="6"/>
         </record>
-
+        
+        <record id="default_schedule_template" model="hr.schedule.template">
+          <field name="name">Schedule Template</field>
+        </record>
     </data>
 </openerp>

--- a/hr_schedule/hr_schedule.py
+++ b/hr_schedule/hr_schedule.py
@@ -1800,11 +1800,31 @@ class hr_contract(orm.Model):
     }
 
     def _get_sched_template(self, cr, uid, context=None):
-
-        res = False
         init = self.get_latest_initial_values(cr, uid, context=context)
         if init is not None and init.sched_template_id:
             res = init.sched_template_id.id
+        else:
+            model_data = self.pool['ir.model.data']
+            try:
+                model, res = model_data.get_object_reference(
+                    cr,
+                    uid,
+                    'hr_schedule',
+                    'default_schedule_template')
+            except ValueError:
+                # the data file has not yet been imported
+                # we create the default record manually
+                sched_tmpl = self.pool['hr.schedule.template']
+                res = sched_tmpl.create(cr, uid,
+                                        {'name': 'Schedule Template'},
+                                        context=context)
+                model_data.create(cr, uid,
+                                  {'module': 'hr_schedule',
+                                   'model': 'hr.schedule.template',
+                                   'name': 'default_schedule_template',
+                                   'res_id': res,
+                                   'noupdate': True},
+                                  context=context)
         return res
 
     _defaults = {

--- a/hr_schedule/hr_schedule.py
+++ b/hr_schedule/hr_schedule.py
@@ -376,8 +376,8 @@ WHERE (date_start <= %s and %s <= date_end)
     def add_restdays(
             self, cr, uid, schedule, field_name, rest_days=None, context=None):
 
-        _logger.warning('field: %s', field_name)
-        _logger.warning('rest_days: %s', rest_days)
+        _logger.debug('field: %s', field_name)
+        _logger.debug('rest_days: %s', rest_days)
         restday_ids = []
         if rest_days is None:
             for rd in schedule.template_id.restday_ids:
@@ -387,7 +387,7 @@ WHERE (date_start <= %s and %s <= date_end)
                 cr, uid, [
                     ('sequence', 'in', rest_days)
                 ], context=context)
-        _logger.warning('restday_ids: %s', restday_ids)
+        _logger.debug('restday_ids: %s', restday_ids)
         if len(restday_ids) > 0:
             self.write(cr, uid, schedule.id, {
                        field_name: [(6, 0, restday_ids)]}, context=context)

--- a/hr_schedule/wizard/restday.py
+++ b/hr_schedule/wizard/restday.py
@@ -322,10 +322,10 @@ class restday(orm.TransientModel):
             }
 
         sched_obj.unlink(cr, uid, schedule_id, context=context)
-        _l.warning('vals1: %s', vals1)
+        _l.debug('vals1: %s', vals1)
         sched_obj.create(cr, uid, vals1, context=context)
         if vals2:
-            _l.warning('vals2: %s', vals2)
+            _l.debug('vals2: %s', vals2)
             sched_obj.create(cr, uid, vals2, context=context)
 
     def _change_by_template(

--- a/hr_skill/hr_skill_view.xml
+++ b/hr_skill/hr_skill_view.xml
@@ -11,7 +11,6 @@
         <field name="name">hr.employee.skill.form</field>
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
-        <field name="type">form</field>
         <field name="arch" type="xml">
             <notebook position="inside">
                 <page string="Skills">
@@ -30,7 +29,6 @@
     <record model="ir.ui.view" id="view_skill_form">
         <field name="name">hr.skill.form</field>
         <field name="model">hr.skill</field>
-        <field name="type">form</field>
         <field name="arch" type="xml">
             <form string="Skill">
                 <field name="name" select="1" colspan="1"/>
@@ -56,7 +54,6 @@
     <record model="ir.ui.view" id="view_hr_skill_tree">
         <field name="name">hr.skill.tree</field>
         <field name="model">hr.skill</field>
-        <field name="type">tree</field>
         <field name="field_parent">child_ids</field>
         <field name="arch" type="xml">
             <tree string="Skills">


### PR DESCRIPTION
- remove type in ir.ui.view xml definitions
- fix a Python SyntaxWarning caused by wrong use of `assert`
- fix the addition of required columns by ensuring they get a value before the NOT NULL sql constraint is added 
- changed WARNING logging to DEBUG where the original logging level was clearly overrated
