### PR TITLE
[FIX] solves an error message when the user enters the employee name,…

### DIFF
--- a/hr_period/models/hr_payslip.py
+++ b/hr_period/models/hr_payslip.py
@@ -89,12 +89,12 @@ class HrPayslip(orm.Model):
             period = self.pool['hr.period'].get_next_period(
                 cr, uid, employee.company_id.id, contract.schedule_pay,
                 context=context)
-
-            res['value'].update({
-                'hr_period_id': period.id if period else False,
-                'name': _('Salary Slip of %s for %s') % (
-                    employee.name, period.name),
-            })
+            if employee and period:
+                res['value'].update({
+                    'hr_period_id': period.id if period else False,
+                    'name': _('Salary Slip of %s for %s') % (
+                        employee.name, period.name),
+                })
 
         return res
 


### PR DESCRIPTION
When a user creates a new payslip and enters the employee the following error message occurs:

File "/home/jordi/openerp70/openerp70/addons/OCA/PR/hr/hr_period/models/hr_payslip.py", line 96, in onchange_contract_id
    employee.name, period.name),
AttributeError: 'bool' object has no attribute 'name'

This is because the period has not yet been entered.

This PR fill only attempt to access to the employee or period data if it has been obtained.
