### PR TITLE
[ADD] hr_payslip_move_date

### DIFF
--- a/hr_payslip_move_date/README.rst
+++ b/hr_payslip_move_date/README.rst
@@ -1,0 +1,60 @@
+HR Payroll Account Date
+=======================
+
+Adds a move date to the payslip.
+Allows the user to propose/force a specific move date.
+If none is proposed, the field will be completed with the actual move date.
+
+
+Usage
+=====
+
+Create a payslip
+----------------
+Go to: Human Resources -> Payroll -> Employe Payslip
+
+- Complete the payslip details
+- Go to 'Other information', 'Accounting' section and complete the field
+'Force move date'.
+
+
+ - Click on Generate Payslips
+
+The employees paid with the selected schedule are automatically selected.
+
+ - Click on Generate
+
+ - Confirm your payslips
+
+ - Click on Close
+
+The payroll period is closed automatically and the next one is open.
+
+
+Known issues / Roadmap
+======================
+
+By default the Salary Journal should be set up with the field 'Check Date in
+ Period' unflagged. Otherwise the application will raise an error message if
+  the user enters a move date corresponding to a past period.
+
+
+Credits
+=======
+
+Contributors
+------------
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/hr_payslip_move_date/README.rst
+++ b/hr_payslip_move_date/README.rst
@@ -11,24 +11,11 @@ Usage
 
 Create a payslip
 ----------------
-Go to: Human Resources -> Payroll -> Employe Payslip
+Go to: Human Resources -> Payroll -> Employee Payslip
 
 - Complete the payslip details
 - Go to 'Other information', 'Accounting' section and complete the field
 'Force move date'.
-
-
- - Click on Generate Payslips
-
-The employees paid with the selected schedule are automatically selected.
-
- - Click on Generate
-
- - Confirm your payslips
-
- - Click on Close
-
-The payroll period is closed automatically and the next one is open.
 
 
 Known issues / Roadmap

--- a/hr_payslip_move_date/__init__.py
+++ b/hr_payslip_move_date/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import models

--- a/hr_payslip_move_date/__openerp__.py
+++ b/hr_payslip_move_date/__openerp__.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    "name": "HR Payslip Move Date",
+    "version": "1.0",
+    "license": 'AGPL-3',
+    "author": "Eficent, Odoo Community Association (OCA)",
+    "category": "Generic Modules/Human Resources",
+    "depends": ["hr_payroll_account"],
+    "description": """
+HR Payslip Move Date
+====================
+Adds a move date to the payslip.
+Allows the user to propose/force a specific move date.
+If none is proposed, the field will be completed with the actual move date.
+    """,
+    "data": [
+        "views/hr_payslip_view.xml",
+    ],
+    'demo': [],
+    'test':[
+    ],
+    'installable': True,
+}

--- a/hr_payslip_move_date/__openerp__.py
+++ b/hr_payslip_move_date/__openerp__.py
@@ -35,7 +35,7 @@ Allows the user to propose/force a specific move date.
 If none is proposed, the field will be completed with the actual move date.
     """,
     "data": [
-        "views/hr_payslip_view.xml",
+        "views/hr_payslip_view.xml"
     ],
     'demo': [],
     'test':[

--- a/hr_payslip_move_date/models/__init__.py
+++ b/hr_payslip_move_date/models/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import hr_payslip

--- a/hr_payslip_move_date/models/hr_payslip.py
+++ b/hr_payslip_move_date/models/hr_payslip.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#               <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, osv, orm
+
+
+class HrPayslip(orm.Model):
+
+    _inherit = 'hr.payslip'
+
+    _columns = {
+        'move_date': fields.date(string='Force move date',
+                                 required=False),
+    }
+
+    def onchange_move_date(self, cr, uid, ids, move_date, context=None):
+        res = {'value': {}}
+        period_obj = self.pool['account.period']
+        if move_date:
+            period_ids = period_obj.find(cr, uid, dt=move_date,
+                                         context=context)
+            if period_ids:
+                res['value']['period_id'] = period_ids[0]
+        return res
+
+    def write(self, cr, uid, ids, vals, context=None):
+        if not context:
+            context = {}
+        move_obj = self.pool['account.move']
+        move_line_obj = self.pool['account.move.line']
+
+        res = super(HrPayslip, self).write(cr, uid, ids, vals, context=context)
+        if 'move_id' in vals and vals['move_id']:
+            for slip in self.browse(cr, uid, ids, context=context):
+                if slip.move_date:
+                    move_obj.write(cr, uid, [slip.move_id.id],
+                                   {'date': slip.move_date}, context=context)
+                    for move_line in slip.move_id.line_id:
+                        move_line_obj.write(cr, uid, [move_line.id],
+                                            {'date': slip.move_date},
+                                            context=context)
+                else:
+                    self.write(cr, uid, [slip.id],
+                               {'move_date': slip.move_id.date},
+                               context=context)
+        return res

--- a/hr_payslip_move_date/models/hr_payslip.py
+++ b/hr_payslip_move_date/models/hr_payslip.py
@@ -61,3 +61,13 @@ class HrPayslip(orm.Model):
                                {'move_date': slip.move_id.date},
                                context=context)
         return res
+
+
+class HrPayslipRun(orm.Model):
+
+    _inherit = 'hr.payslip.run'
+
+    _columns = {
+        'move_date': fields.date(string='Force move date',
+                                 required=False),
+    }

--- a/hr_payslip_move_date/views/hr_payslip_view.xml
+++ b/hr_payslip_move_date/views/hr_payslip_view.xml
@@ -15,5 +15,17 @@
             </field>
         </record>
 
+        <record id="hr_payslip_run_form_inherit" model="ir.ui.view">
+            <field name="name">hr.payslip.run.form</field>
+            <field name="model">hr.payslip.run</field>
+            <field name="inherit_id"
+                   ref="hr_payroll_account.hr_payslip_run_form_inherit"/>
+            <field name="arch" type="xml">
+                <field name="journal_id" position="before">
+                    <field name="move_date"/>
+                </field>
+            </field>
+        </record>
+
     </data>
 </openerp>

--- a/hr_payslip_move_date/views/hr_payslip_view.xml
+++ b/hr_payslip_move_date/views/hr_payslip_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="view_hr_payslip_inherit_form">
+            <field name="name">hr.payslip.inherit.form</field>
+            <field name="model">hr.payslip</field>
+            <field name="inherit_id"
+                   ref="hr_payroll_account.view_hr_payslip_inherit_form"/>
+            <field name="arch" type="xml">
+                <field name="period_id" position="before">
+                    <field name="move_date"
+                           on_change="onchange_move_date(move_date)"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/hr_payslip_move_date/wizard/__init__.py
+++ b/hr_payslip_move_date/wizard/__init__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
-#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#    Copyright (C) 2015 Eficent
+#    (<http://www.eficent.com>)
 #
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -18,5 +18,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from . import models
-from . import wizard
+from . import hr_payroll_payslips_by_employees

--- a/hr_payslip_move_date/wizard/hr_payroll_payslips_by_employees.py
+++ b/hr_payslip_move_date/wizard/hr_payroll_payslips_by_employees.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, orm
+
+
+class HrPayslipEmployees(orm.TransientModel):
+
+    _inherit = 'hr.payslip.employees'
+
+    def compute_sheet(self, cr, uid, ids, context=None):
+
+        res = super(HrPayslipEmployees, self).compute_sheet(cr, uid, ids,
+                                                            context=context)
+        payslip_run = self.pool['hr.payslip.run'].browse(
+                cr, uid, context['active_id'], context=context)
+        move_date = payslip_run.move_date
+        if move_date:
+            period_obj = self.pool['account.period']
+            period_ids = period_obj.find(cr, uid,
+                                         dt=move_date,
+                                         context=context)
+            if period_ids:
+                period_id = period_ids[0]
+            else:
+                period_id = False
+            slip_ids = [slip.id for slip in payslip_run.slip_ids]
+            self.pool['hr.payslip'].write(cr, uid, slip_ids,
+                                          {'move_date': move_date,
+                                           'period_id': period_id},
+                                          context=context)
+        return res


### PR DESCRIPTION
# HR Payroll Account Date

Adds a move date to the payslip.
Allows the user to propose/force a specific move date.
If none is proposed, the field will be completed with the actual move date.
# Usage
## Create a payslip

Go to: Human Resources -> Payroll -> Employee Payslip
- Complete the payslip details
- Go to 'Other information', 'Accounting' section and complete the field
  'Force move date'.
# Known issues / Roadmap

By default the Salary Journal should be set up with the field 'Check Date in
 Period' unflagged. Otherwise the application will raise an error message if
  the user enters a move date corresponding to a past period.
