### PR TITLE
[ADD] Payroll Contribution Register Report

### DIFF
--- a/hr_payroll_report_contrib_register/README.rst
+++ b/hr_payroll_report_contrib_register/README.rst
@@ -1,3 +1,8 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+====================================
 Payroll Contribution Register Report
 ====================================
 
@@ -21,14 +26,32 @@ Configuration
 No configuration necessary
 
 
+
 Usage
 =====
 
 
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/{repo_id}/{branch}
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
 Known issues / Roadmap
 ======================
 
-None
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/
+{project_repo}/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
+{project_repo}/issues/new?body=module:%20
+{module_name}%0Aversion:%20
+{version}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 
 Credits
@@ -36,17 +59,20 @@ Credits
 
 Contributors
 ------------
+
 * Salton Massally <smassally@idtlabs.sl>
 
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
-OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
 
 To contribute to this module, please visit http://odoo-community.org.

--- a/hr_payroll_report_contrib_register/README.rst
+++ b/hr_payroll_report_contrib_register/README.rst
@@ -1,0 +1,52 @@
+Payroll Contribution Register Report
+====================================
+
+Prints the contribution registers for a payroll run.
+This addon makes it easy to print the contribution register from within the 
+payroll run rather than having to each contribution register which is located 
+in the configuration section of HR. 
+
+Another important feature of this addon it that the payslip line considered
+in the report are those belonging to payslips in the runs can overlap in dates
+
+Installation
+============
+
+Install as usual by going to the module install screen
+
+
+Configuration
+=============
+
+No configuration necessary
+
+
+Usage
+=====
+
+
+Known issues / Roadmap
+======================
+
+None
+
+
+Credits
+=======
+
+Contributors
+------------
+* Salton Massally <smassally@idtlabs.sl>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/hr_payroll_report_contrib_register/__init__.py
+++ b/hr_payroll_report_contrib_register/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding:utf-8 -*-
+from . import wizard
+from . import report

--- a/hr_payroll_report_contrib_register/__init__.py
+++ b/hr_payroll_report_contrib_register/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ###############################################################################
 #
-#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as

--- a/hr_payroll_report_contrib_register/__init__.py
+++ b/hr_payroll_report_contrib_register/__init__.py
@@ -1,3 +1,21 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
 from . import wizard
 from . import report

--- a/hr_payroll_report_contrib_register/__openerp__.py
+++ b/hr_payroll_report_contrib_register/__openerp__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ###############################################################################
 #
-#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -20,7 +20,8 @@
 
 {
     'name': 'Payroll Contribution Register Report',
-    'version': '1.0',
+    'version': '8.0.1.0.0',
+    'license': 'AGPL-3',
     'category': 'Human Resources',
     'summary': "Print Contribution register from payroll run",
     'author': "Salton Massally <smassally@idtlabs.sl>, "

--- a/hr_payroll_report_contrib_register/__openerp__.py
+++ b/hr_payroll_report_contrib_register/__openerp__.py
@@ -1,0 +1,18 @@
+# -*- coding:utf-8 -*-
+
+{
+    'name': 'Payroll Contribution Register Report',
+    'version': '1.0',
+    'category': 'Human Resources',
+    'summary': "Print Contribution register from payroll run",
+    'author': "Salton Massally <smassally@idtlabs.sl>, "
+               "Odoo Community Association (OCA)",
+    'website': 'http://idtlabs.sl',
+    'license': 'AGPL-3',
+    'depends': ['hr_payroll'],
+    'data': [
+        'wizard/print_contribution_register_view.xml',
+        'contrib_register_report.xml'
+    ],
+    'installable': True,
+}

--- a/hr_payroll_report_contrib_register/__openerp__.py
+++ b/hr_payroll_report_contrib_register/__openerp__.py
@@ -1,4 +1,22 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
 
 {
     'name': 'Payroll Contribution Register Report',

--- a/hr_payroll_report_contrib_register/contrib_register_report.xml
+++ b/hr_payroll_report_contrib_register/contrib_register_report.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <report 
+            id="action_contribution_register" 
+            model="hr.contribution.register" 
+            string="PaySlip Lines By Conribution Register"
+            report_type="qweb-pdf"
+            name="hr_payroll_report_contrib_register.report_contributionregister" 
+            file="hr_payroll_report_contrib_register.report_contributionregister"
+            menu="False"
+        />
+    </data>
+</openerp>

--- a/hr_payroll_report_contrib_register/report/__init__.py
+++ b/hr_payroll_report_contrib_register/report/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ###############################################################################
 #
-#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as

--- a/hr_payroll_report_contrib_register/report/__init__.py
+++ b/hr_payroll_report_contrib_register/report/__init__.py
@@ -1,0 +1,4 @@
+#-*- coding:utf-8 -*-
+import report_contribution_register
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/hr_payroll_report_contrib_register/report/__init__.py
+++ b/hr_payroll_report_contrib_register/report/__init__.py
@@ -17,4 +17,4 @@
 #    along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 ###############################################################################
-import report_contribution_register
+from . import report_contribution_register

--- a/hr_payroll_report_contrib_register/report/__init__.py
+++ b/hr_payroll_report_contrib_register/report/__init__.py
@@ -1,4 +1,22 @@
-#-*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
 import report_contribution_register
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/hr_payroll_report_contrib_register/report/__init__.py
+++ b/hr_payroll_report_contrib_register/report/__init__.py
@@ -18,5 +18,3 @@
 #
 ###############################################################################
 import report_contribution_register
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/hr_payroll_report_contrib_register/report/report_contribution_register.py
+++ b/hr_payroll_report_contrib_register/report/report_contribution_register.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ###############################################################################
 #
-#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as

--- a/hr_payroll_report_contrib_register/report/report_contribution_register.py
+++ b/hr_payroll_report_contrib_register/report/report_contribution_register.py
@@ -1,4 +1,22 @@
-#-*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
 import time
 from datetime import datetime
 from dateutil import relativedelta
@@ -8,17 +26,29 @@ from openerp.report import report_sxw
 
 class contribution_register_report(report_sxw.rml_parse):
     def __init__(self, cr, uid, name, context):
-        super(contribution_register_report, self).__init__(cr, uid, name, context)
+        super(contribution_register_report, self).__init__(
+            cr, uid, name, context)
         self.localcontext.update({
             'get_payslip_lines': self._get_payslip_lines,
             'sum_total': self.sum_total,
         })
 
     def set_context(self, objects, data, ids, report_type=None):
-        self.date_from = data['form'].get('date_from', time.strftime('%Y-%m-%d'))
-        self.date_to = data['form'].get('date_to', str(datetime.now() + relativedelta.relativedelta(months=+1, day=1, days=-1))[:10])
+        self.date_from = data['form'].get(
+            'date_from',
+            time.strftime('%Y-%m-%d')
+        )
+        self.date_to = data['form'].get(
+            'date_to',
+            str(
+                datetime.now()
+                + relativedelta.relativedelta(months=+1, day=1, days=-1)
+            )[:10]
+        )
         self.slip_ids = data['form'].get('slip_ids', [])
-        return super(contribution_register_report, self).set_context(objects, data, ids, report_type=report_type)
+        return super(contribution_register_report, self).set_context(
+            objects, data, ids, report_type=report_type
+        )
 
     def sum_total(self):
         return self.regi_total
@@ -28,14 +58,15 @@ class contribution_register_report(report_sxw.rml_parse):
         payslip_lines = []
         res = []
         self.regi_total = 0.0
-        self.cr.execute("SELECT pl.id from hr_payslip_line as pl "\
-                        "LEFT JOIN hr_payslip AS hp on (pl.slip_id = hp.id) "\
-                        "WHERE (hp.date_from >= %s) AND (hp.date_to <= %s) "\
-                        "AND pl.register_id = %s "\
-                        "AND hp.state = 'done' "\
-                        "AND hp.id in %s"\
+        self.cr.execute("SELECT pl.id from hr_payslip_line as pl "
+                        "LEFT JOIN hr_payslip AS hp on (pl.slip_id = hp.id) "
+                        "WHERE (hp.date_from >= %s) AND (hp.date_to <= %s) "
+                        "AND pl.register_id = %s "
+                        "AND hp.state = 'done' "
+                        "AND hp.id in %s"
                         "ORDER BY pl.slip_id, pl.sequence",
-                        (self.date_from, self.date_to, obj.id, tuple(self.slip_ids)))
+                        (self.date_from, self.date_to, obj.id,
+                            tuple(self.slip_ids)))
         payslip_lines = [x[0] for x in self.cr.fetchall()]
         for line in payslip_line.browse(self.cr, self.uid, payslip_lines):
             res.append({
@@ -51,7 +82,8 @@ class contribution_register_report(report_sxw.rml_parse):
 
 
 class wrapped_report_contribution_register(osv.AbstractModel):
-    _name = 'report.hr_payroll_report_contrib_register.report_contributionregister'
+    _name = \
+        'report.hr_payroll_report_contrib_register.report_contributionregister'
     _inherit = 'report.abstract_report'
     _template = 'hr_payroll.report_contributionregister'
     _wrapped_report_class = contribution_register_report

--- a/hr_payroll_report_contrib_register/report/report_contribution_register.py
+++ b/hr_payroll_report_contrib_register/report/report_contribution_register.py
@@ -82,10 +82,9 @@ class contribution_register_report(report_sxw.rml_parse):
 
 
 class wrapped_report_contribution_register(osv.AbstractModel):
-    _name = \
+    _name = (
         'report.hr_payroll_report_contrib_register.report_contributionregister'
+    )
     _inherit = 'report.abstract_report'
     _template = 'hr_payroll.report_contributionregister'
     _wrapped_report_class = contribution_register_report
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/hr_payroll_report_contrib_register/report/report_contribution_register.py
+++ b/hr_payroll_report_contrib_register/report/report_contribution_register.py
@@ -1,0 +1,59 @@
+#-*- coding:utf-8 -*-
+import time
+from datetime import datetime
+from dateutil import relativedelta
+from openerp.osv import osv
+from openerp.report import report_sxw
+
+
+class contribution_register_report(report_sxw.rml_parse):
+    def __init__(self, cr, uid, name, context):
+        super(contribution_register_report, self).__init__(cr, uid, name, context)
+        self.localcontext.update({
+            'get_payslip_lines': self._get_payslip_lines,
+            'sum_total': self.sum_total,
+        })
+
+    def set_context(self, objects, data, ids, report_type=None):
+        self.date_from = data['form'].get('date_from', time.strftime('%Y-%m-%d'))
+        self.date_to = data['form'].get('date_to', str(datetime.now() + relativedelta.relativedelta(months=+1, day=1, days=-1))[:10])
+        self.slip_ids = data['form'].get('slip_ids', [])
+        return super(contribution_register_report, self).set_context(objects, data, ids, report_type=report_type)
+
+    def sum_total(self):
+        return self.regi_total
+
+    def _get_payslip_lines(self, obj):
+        payslip_line = self.pool.get('hr.payslip.line')
+        payslip_lines = []
+        res = []
+        self.regi_total = 0.0
+        self.cr.execute("SELECT pl.id from hr_payslip_line as pl "\
+                        "LEFT JOIN hr_payslip AS hp on (pl.slip_id = hp.id) "\
+                        "WHERE (hp.date_from >= %s) AND (hp.date_to <= %s) "\
+                        "AND pl.register_id = %s "\
+                        "AND hp.state = 'done' "\
+                        "AND hp.id in %s"\
+                        "ORDER BY pl.slip_id, pl.sequence",
+                        (self.date_from, self.date_to, obj.id, tuple(self.slip_ids)))
+        payslip_lines = [x[0] for x in self.cr.fetchall()]
+        for line in payslip_line.browse(self.cr, self.uid, payslip_lines):
+            res.append({
+                'payslip_name': line.slip_id.name,
+                'name': line.name,
+                'code': line.code,
+                'quantity': line.quantity,
+                'amount': line.amount,
+                'total': line.total,
+            })
+            self.regi_total += line.total
+        return res
+
+
+class wrapped_report_contribution_register(osv.AbstractModel):
+    _name = 'report.hr_payroll_report_contrib_register.report_contributionregister'
+    _inherit = 'report.abstract_report'
+    _template = 'hr_payroll.report_contributionregister'
+    _wrapped_report_class = contribution_register_report
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/hr_payroll_report_contrib_register/report/report_contribution_register.py
+++ b/hr_payroll_report_contrib_register/report/report_contribution_register.py
@@ -24,9 +24,9 @@ from openerp.osv import osv
 from openerp.report import report_sxw
 
 
-class contribution_register_report(report_sxw.rml_parse):
+class ContributionRegisterReport(report_sxw.rml_parse):
     def __init__(self, cr, uid, name, context):
-        super(contribution_register_report, self).__init__(
+        super(ContributionRegisterReport, self).__init__(
             cr, uid, name, context)
         self.localcontext.update({
             'get_payslip_lines': self._get_payslip_lines,
@@ -46,7 +46,7 @@ class contribution_register_report(report_sxw.rml_parse):
             )[:10]
         )
         self.slip_ids = data['form'].get('slip_ids', [])
-        return super(contribution_register_report, self).set_context(
+        return super(ContributionRegisterReport, self).set_context(
             objects, data, ids, report_type=report_type
         )
 
@@ -81,10 +81,10 @@ class contribution_register_report(report_sxw.rml_parse):
         return res
 
 
-class wrapped_report_contribution_register(osv.AbstractModel):
+class WrappedReportContributionRegister(osv.AbstractModel):
     _name = (
         'report.hr_payroll_report_contrib_register.report_contributionregister'
     )
     _inherit = 'report.abstract_report'
     _template = 'hr_payroll.report_contributionregister'
-    _wrapped_report_class = contribution_register_report
+    _wrapped_report_class = ContributionRegisterReport

--- a/hr_payroll_report_contrib_register/wizard/__init__.py
+++ b/hr_payroll_report_contrib_register/wizard/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ###############################################################################
 #
-#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as

--- a/hr_payroll_report_contrib_register/wizard/__init__.py
+++ b/hr_payroll_report_contrib_register/wizard/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding:utf-8 -*-
+from . import print_contribution_register

--- a/hr_payroll_report_contrib_register/wizard/__init__.py
+++ b/hr_payroll_report_contrib_register/wizard/__init__.py
@@ -1,2 +1,20 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
 from . import print_contribution_register

--- a/hr_payroll_report_contrib_register/wizard/print_contribution_register.py
+++ b/hr_payroll_report_contrib_register/wizard/print_contribution_register.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ###############################################################################
 #
-#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as

--- a/hr_payroll_report_contrib_register/wizard/print_contribution_register.py
+++ b/hr_payroll_report_contrib_register/wizard/print_contribution_register.py
@@ -1,5 +1,23 @@
-# -*- coding:utf-8 -*-
-from openerp import models, fields, api, _
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2016 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from openerp import models, fields, api
 
 
 class print_run_contrib_register(models.TransientModel):
@@ -7,10 +25,10 @@ class print_run_contrib_register(models.TransientModel):
     _description = 'Print Contribution Register'
 
     contrib_register_ids = fields.Many2many(
-                                            'hr.contribution.register',
-                                            string="Contribution Registers"
-                                            )
-    
+        'hr.contribution.register',
+        string="Contribution Registers"
+    )
+
     @api.multi
     def print_contrib_register(self):
         self.ensure_one()
@@ -18,16 +36,19 @@ class print_run_contrib_register(models.TransientModel):
         run = self.env['hr.payslip.run'].browse(run_id)
 
         datas = {
-             'model': 'hr.contribution.register', 
-             'ids'  : self.contrib_register_ids.ids,
-             'form' : {
-                       'date_from': run.date_start,
-                       'date_to'  : run.date_end,
-                       'slip_ids' : run.slip_ids.ids,
-                       }
-         }
-        report_obj = self.env['report'].with_context(active_ids=self.contrib_register_ids.ids,
-                                                     active_model='hr.contribution.register')
-        return report_obj.get_action(self.contrib_register_ids, 'hr_payroll_report_contrib_register.report_contributionregister',
-                                     data=datas)
- 
+            'model': 'hr.contribution.register',
+            'ids': self.contrib_register_ids.ids,
+            'form': {
+                'date_from': run.date_start,
+                'date_to': run.date_end,
+                'slip_ids': run.slip_ids.ids,
+            }
+        }
+        report_obj = self.env['report'].with_context(
+            active_ids=self.contrib_register_ids.ids,
+            active_model='hr.contribution.register')
+        return report_obj.get_action(
+            self.contrib_register_ids,
+            'hr_payroll_report_contrib_register.report_contributionregister',
+            data=datas
+        )

--- a/hr_payroll_report_contrib_register/wizard/print_contribution_register.py
+++ b/hr_payroll_report_contrib_register/wizard/print_contribution_register.py
@@ -1,0 +1,33 @@
+# -*- coding:utf-8 -*-
+from openerp import models, fields, api, _
+
+
+class print_run_contrib_register(models.TransientModel):
+    _name = 'print.run.contrib_register'
+    _description = 'Print Contribution Register'
+
+    contrib_register_ids = fields.Many2many(
+                                            'hr.contribution.register',
+                                            string="Contribution Registers"
+                                            )
+    
+    @api.multi
+    def print_contrib_register(self):
+        self.ensure_one()
+        run_id = self.env.context['active_id']
+        run = self.env['hr.payslip.run'].browse(run_id)
+
+        datas = {
+             'model': 'hr.contribution.register', 
+             'ids'  : self.contrib_register_ids.ids,
+             'form' : {
+                       'date_from': run.date_start,
+                       'date_to'  : run.date_end,
+                       'slip_ids' : run.slip_ids.ids,
+                       }
+         }
+        report_obj = self.env['report'].with_context(active_ids=self.contrib_register_ids.ids,
+                                                     active_model='hr.contribution.register')
+        return report_obj.get_action(self.contrib_register_ids, 'hr_payroll_report_contrib_register.report_contributionregister',
+                                     data=datas)
+ 

--- a/hr_payroll_report_contrib_register/wizard/print_contribution_register.py
+++ b/hr_payroll_report_contrib_register/wizard/print_contribution_register.py
@@ -20,7 +20,7 @@
 from openerp import models, fields, api
 
 
-class print_run_contrib_register(models.TransientModel):
+class PrintRunContribRegister(models.TransientModel):
     _name = 'print.run.contrib_register'
     _description = 'Print Contribution Register'
 

--- a/hr_payroll_report_contrib_register/wizard/print_contribution_register_view.xml
+++ b/hr_payroll_report_contrib_register/wizard/print_contribution_register_view.xml
@@ -22,7 +22,7 @@
 
     <!-- Wizard action -->
     <record id="action_print_run_contrib_register" model="ir.actions.act_window">
-      <field name="name">Print Contribution Register</field>
+      <field name="name">Contribution Registers</field>
       <field name="type">ir.actions.act_window</field>
       <field name="res_model">print.run.contrib_register</field>
       <field name="view_type">form</field>

--- a/hr_payroll_report_contrib_register/wizard/print_contribution_register_view.xml
+++ b/hr_payroll_report_contrib_register/wizard/print_contribution_register_view.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+   
+    <!-- Wizard view -->
+    <record id="print_run_contrib_register_form" model="ir.ui.view">
+      <field name="name">print.run.contrib_register.form</field>
+      <field name="model">print.run.contrib_register</field>
+      <field name="arch" type="xml">
+        <form string="Print Contribution Register">
+          <group>
+            <field name="contrib_register_ids" nolabel="1"/>
+          </group>
+          <footer>
+            <button name="print_contrib_register" string="Print Registers" type="object" class="oe_highlight"/>
+            or
+            <button string="Cancel" class="oe_link" special="cancel"/>
+          </footer>
+        </form>
+      </field>
+    </record>
+
+    <!-- Wizard action -->
+    <record id="action_print_run_contrib_register" model="ir.actions.act_window">
+      <field name="name">Print Contribution Register</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="res_model">print.run.contrib_register</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">form</field>
+      <field name="target">new</field>
+    </record>
+
+    <!-- Action placement -->
+    <record model="ir.values" id="payroll_run_contrib_register_print">
+            <field name="model_id" ref="hr_payroll.model_hr_payslip_run"/>
+            <field name="name">Print Contrib Register</field>
+            <field name="key2">client_print_multi</field>
+            <field name="value"
+                eval="'ir.actions.act_window,' +str(ref('action_print_run_contrib_register'))"/>
+            <field name="key">action</field>
+            <field name="model">hr.payslip.run</field>
+        </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
This addon solves two things about printing contribution registers that is undesirable:
- You can only print contribution registers via configuration > contribution
- If you have two runs that overlap in date it is impossible to print run specific contributionn register
  Consequently this addon allowa you to print contibution registers for payslip lines in the run directly from the payslip
