### PR TITLE
[9.0] port hr_worked_days_hourly_rate

### DIFF
--- a/hr_worked_days_hourly_rate/__openerp__.py
+++ b/hr_worked_days_hourly_rate/__openerp__.py
@@ -46,5 +46,7 @@ Contributors
     ],
     'test': [],
     'demo': [],
-    'installable': False,
+    'installable': True,
+    'auto_install': False,
+    'application': False
 }


### PR DESCRIPTION
This module is compatible with Odoo 9.0 version. 
It's installable and all unit tests pass without error.

<i>sorry for my english</i> ^.^
