### PR TITLE
[ADD] hr_holidays_legal_leave

### DIFF
--- a/hr_holidays_legal_leave/README.rst
+++ b/hr_holidays_legal_leave/README.rst
@@ -1,0 +1,78 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+HR Holidays Legal Leave
+=======================
+
+Allows the define what holiday type is to be considered legal/annual leave type.
+As currently is Odoo assumes the type with limit=False which is a problem if
+you have more than one leave type limited this becomes confusing especially
+when tying to set leaves from the employee form
+
+Installation
+============
+
+No additional steps necessary
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+Multi-Company setup
+* Go to the company and select the leave type to use as legal leave
+
+Regular Setup
+* Assign legal leave type via Settings > Human Resources
+
+Usage
+=====
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/{repo_id}/{branch}
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+Known issues / Roadmap
+======================
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/
+{project_repo}/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
+{project_repo}/issues/new?body=module:%20
+{module_name}%0Aversion:%20
+{version}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Salton Massally <smassally@idtlabs.sl>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/hr_holidays_legal_leave/README.rst
+++ b/hr_holidays_legal_leave/README.rst
@@ -9,7 +9,7 @@ HR Holidays Legal Leave
 Allows the define what holiday type is to be considered legal/annual leave type.
 As currently is Odoo assumes the type with limit=False which is a problem if
 you have more than one leave type limited this becomes confusing especially
-when tying to set leaves from the employee form
+when tying to set leaves from the employee form.
 
 Installation
 ============

--- a/hr_holidays_legal_leave/__init__.py
+++ b/hr_holidays_legal_leave/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from . import models

--- a/hr_holidays_legal_leave/__openerp__.py
+++ b/hr_holidays_legal_leave/__openerp__.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+{
+    'name': 'HR Holidays Legal Leave',
+    'version': '8.0.1.0.0',
+    'category': 'Human Resources',
+    'license': 'AGPL-3',
+    'summary': 'Allows the definition of legal/annual leave',
+    'author': 'Salton Massally<smassally@idtlabs.sl>, '
+              'Odoo Community Association (OCA)',
+    'website': 'http://idtlabs.sl',
+    'depends': ['hr_holidays'],
+    'data': [
+        'views/res_config.xml',
+        'views/res_company.xml',
+    ],
+    'installable': True,
+}

--- a/hr_holidays_legal_leave/models/__init__.py
+++ b/hr_holidays_legal_leave/models/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from . import res_config
+from . import res_company
+from . import hr_employee

--- a/hr_holidays_legal_leave/models/hr_employee.py
+++ b/hr_holidays_legal_leave/models/hr_employee.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from openerp import models, api, fields
+from openerp.exceptions import Warning as UserWarning
+
+
+class HrEmployee(models.Model):
+    _inherit = 'hr.employee'
+
+    @api.one
+    def _inverse_remaining_days(self):
+        legal_leave = self.company_id.legal_holidays_status_id
+        if not legal_leave:
+            raise UserWarning('Legal/annual leave type is not defined for '
+                              'your company')
+        diff = self.remaining_leaves - legal_leave.get_days(
+            self.id)[legal_leave.id]['remaining_leaves']
+        if diff > 0:
+            leave = self.env['hr.holidays'].create(
+                {
+                    'name': 'Allocation for %s' % self.name,
+                    'employee_id': self.id,
+                    'holiday_status_id': legal_leave.id,
+                    'type': 'add',
+                    'holiday_type': 'employee',
+                    'number_of_days_temp': diff
+                }
+            )
+        elif diff < 0:
+            raise UserWarning(
+                'You cannot reduce validated allocation requests')
+
+        for sig in ('confirm', 'validate', 'second_validate'):
+            leave.signal_workflow(sig)
+
+    @api.one
+    def _compute_remaining_days(self):
+        legal_leave = self.company_id.legal_holidays_status_id
+        if not legal_leave:
+            raise UserWarning('Legal/annual leave type is not defined for '
+                              'your company')
+        self.remaining_leaves = legal_leave.get_days(
+            self.id)[legal_leave.id]['remaining_leaves']
+
+    remaining_leaves = fields.Integer(
+        'Remaining Legal Leaves',
+        compute='_compute_remaining_days',
+        inverse='_inverse_remaining_days',
+        help='Total number of legal leaves allocated to this employee, '
+             'change this value to create allocation/leave request. '
+             'Total based on all the leave types without overriding limit.'
+    )

--- a/hr_holidays_legal_leave/models/res_company.py
+++ b/hr_holidays_legal_leave/models/res_company.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from openerp import models, fields
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    legal_holidays_status_id = fields.Many2one(
+        'hr.holidays.status',
+        'Legal Leave Status',
+    )

--- a/hr_holidays_legal_leave/models/res_config.py
+++ b/hr_holidays_legal_leave/models/res_config.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from openerp import fields, models, api
+
+
+class HumanResourcesConfiguration(models.TransientModel):
+    _inherit = 'hr.config.settings'
+
+    legal_holidays_status_id = fields.Many2one(
+        'hr.holidays.status',
+        'Legal Leave Status',
+    )
+
+    @api.model
+    def get_legal_holidays_status_id(self, fields):
+        company = self.env.user.company_id
+        return {
+            'legal_holidays_status_id': company.legal_holidays_status_id.id,
+        }
+
+    @api.one
+    def set_legal_holidays_status_id(self):
+        company = self.env.user.company_id
+        company.legal_holidays_status_id = self.legal_holidays_status_id.id

--- a/hr_holidays_legal_leave/tests/__init__.py
+++ b/hr_holidays_legal_leave/tests/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from . import test_holidays_legal_leave

--- a/hr_holidays_legal_leave/tests/test_holidays_legal_leave.py
+++ b/hr_holidays_legal_leave/tests/test_holidays_legal_leave.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from openerp.tests import common
+from openerp.exceptions import Warning as UserWarning
+
+
+class TestHolidaysLegalLeave(common.TransactionCase):
+
+    def setUp(self):
+        super(TestHolidaysLegalLeave, self).setUp()
+        self.employee_model = self.env['hr.employee']
+        self.holiday_status_model = self.env['hr.holidays.status']
+        self.holiday_model = self.env['hr.holidays']
+
+        self.company = self.env.ref('base.main_company')
+
+        # Create an employees
+        self.employee = self.employee_model.create({
+            'name': 'Employee 1',
+        })
+
+        # create leave type
+        self.holiday_status = self.holiday_status_model.create(
+            {
+                'name': 'Leave',
+                'limit': True,
+            }
+        )
+        self.company.legal_holidays_status_id = self.holiday_status.id
+        self.holiday = self.holiday_model.create({
+            'name': 'Hol10',
+            'employee_id': self.employee.id,
+            'type': 'add',
+            'holiday_type': 'employee',
+            'holiday_status_id': self.holiday_status.id,
+            'number_of_days_temp': 10
+        })
+        for sig in ('confirm', 'validate', 'second_validate'):
+            self.holiday.signal_workflow(sig)
+
+    def test_try_reduce_allocation(self):
+        # let's sattempt to reduce allocation here... it should not let us
+        with self.assertRaises(UserWarning):
+            self.employee.write({'remaining_leaves': 5})
+
+    def test_getting_remaining(self):
+        # let's attempt getting remaining leave
+        self.assertEqual(self.employee.remaining_leaves, 10)
+
+    def test_setting_remaining(self):
+        # let's attempt setting remaining leave
+        self.employee.write({'remaining_leaves': 20})
+        self.assertEqual(self.employee.remaining_leaves, 20)

--- a/hr_holidays_legal_leave/views/res_company.xml
+++ b/hr_holidays_legal_leave/views/res_company.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_company_form" model="ir.ui.view">
+            <field name="name">res.company.sheet</field>
+            <field name="model">res.company</field>
+            <field name="inherit_id" ref="base.view_company_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='account_grp']"
+                    position="after">
+                    <group name="hr_holidays_grp" string="Employee Holidays">
+                        <field name="legal_holidays_status_id" />
+                    </group>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/hr_holidays_legal_leave/views/res_config.xml
+++ b/hr_holidays_legal_leave/views/res_config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_hr_config_inherit" model="ir.ui.view">
+            <field name="name">hr settings for payroll</field>
+            <field name="model">hr.config.settings</field>
+            <field name="inherit_id" ref="hr.view_human_resources_configuration" />
+            <field name="arch" type="xml">
+                <xpath expr="//div[@name='hr_attendance']"
+                    position="after">
+                    <div>
+                        <label for="legal_holidays_status_id"
+                            class="oe_inline" />
+                        <field name="legal_holidays_status_id"
+                            class="oe_inline" />
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Allows you to define what holiday type is to be considered legal/annual leave type.
As currently is Odoo assumes the type with limit=False which is a problem if
you have more than one leave type limited this becomes confusing especially
when tying to set leaves from the employee form
