### PR TITLE
[FIX] Incorrect logic to determine if two periods overlap.

### DIFF
--- a/hr_worked_days_from_timesheet/hr_payslip.py
+++ b/hr_worked_days_from_timesheet/hr_payslip.py
@@ -44,11 +44,6 @@ class hr_payslip(orm.Model):
         worked_days = {}
         # Create one worked days record for each timesheet sheet
         for ts_sheet in timesheet_sheets:
-            # Get formated date from the timesheet sheet
-            date_from = datetime.strptime(
-                ts_sheet.date_from,
-                DEFAULT_SERVER_DATE_FORMAT
-            ).strftime(date_format)
             # Create a worked days record with no time
             worked_days[ts_sheet.id] = {
                 'name': _('Timesheet %s') % date_from,

--- a/hr_worked_days_from_timesheet/hr_payslip.py
+++ b/hr_worked_days_from_timesheet/hr_payslip.py
@@ -146,8 +146,8 @@ class hr_payslip(orm.Model):
             if (
                 # We need only the timesheet sheets that overlap
                 # the payslip period.
-                date_from <= ts_sheet.date_from <= date_to or
-                date_from <= ts_sheet.date_to <= date_to
+                date_from <= ts_sheet.date_to and
+                ts_sheet.date_from <= date_to
 
                 # We want only approved timesheets
             ) and ts_sheet.state == 'done'


### PR DESCRIPTION
The current logic to determine if there's a timesheet that overlaps with the payslip period is incorrect. 

For example, given a pay period: 
From: 01/07/2015
To: 01/20/2015

And an approved employee timesheet with date ranges:
From: 01/05/2015
To: 01/27/2015

The current logic will fail to identify that the two periods overlap (but it's obvious that they do overlap..).

The fix consists of applyting the simple logic described here:
http://c2.com/cgi/wiki?TestIfDateRangesOverlap
