### PR TITLE
[FIX] Update tests in hr_employee_firstname - failing travis

### DIFF
--- a/hr_employee_firstname/__init__.py
+++ b/hr_employee_firstname/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/hr_employee_firstname/__openerp__.py
+++ b/hr_employee_firstname/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/hr_employee_firstname/__openerp__.py
+++ b/hr_employee_firstname/__openerp__.py
@@ -22,7 +22,7 @@
 
 {
     'name': 'HR Employee First Name, Last Name',
-    'version': '8.0.0.0.1',
+    'version': '8.0.0.0.2',
     'author': "Savoir-faire Linux, "
               "Fekete Mihai (Forest and Biomass Services Romania), "
               "Odoo Community Association (OCA)",

--- a/hr_employee_firstname/models/__init__.py
+++ b/hr_employee_firstname/models/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -84,7 +84,8 @@ class HrEmployee(models.Model):
             vals['name'] = self._get_name(vals['lastname'], vals['firstname'])
 
         elif vals.get('name'):
-            vals['lastname'], vals['firstname'] = self.split_name(vals['name'])
+            vals['lastname'] = self.split_name(vals['name'])['lastname']
+            vals['firstname'] =  self.split_name(vals['name'])['firstname']
         res = super(HrEmployee, self).create(vals)
         self._update_partner_firstname(res)
         return res
@@ -96,7 +97,8 @@ class HrEmployee(models.Model):
             firstname = vals.get('firstname') or self.firstname or ' '
             vals['name'] = self._get_name(lastname, firstname)
         elif vals.get('name'):
-            vals['lastname'], vals['firstname'] = self.split_name(vals['name'])
+            vals['lastname'] = self.split_name(vals['name'])['lastname']
+            vals['firstname'] =  self.split_name(vals['name'])['firstname']
         res = super(HrEmployee, self).write(vals)
         if set(vals).intersection(UPDATE_PARTNER_FIELDS):
             self._update_partner_firstname(self)

--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
@@ -85,7 +85,7 @@ class HrEmployee(models.Model):
 
         elif vals.get('name'):
             vals['lastname'] = self.split_name(vals['name'])['lastname']
-            vals['firstname'] =  self.split_name(vals['name'])['firstname']
+            vals['firstname'] = self.split_name(vals['name'])['firstname']
         res = super(HrEmployee, self).create(vals)
         self._update_partner_firstname(res)
         return res
@@ -98,7 +98,7 @@ class HrEmployee(models.Model):
             vals['name'] = self._get_name(lastname, firstname)
         elif vals.get('name'):
             vals['lastname'] = self.split_name(vals['name'])['lastname']
-            vals['firstname'] =  self.split_name(vals['name'])['firstname']
+            vals['firstname'] = self.split_name(vals['name'])['firstname']
         res = super(HrEmployee, self).write(vals)
         if set(vals).intersection(UPDATE_PARTNER_FIELDS):
             self._update_partner_firstname(self)

--- a/hr_employee_firstname/tests/test_hr_employee_firstname.py
+++ b/hr_employee_firstname/tests/test_hr_employee_firstname.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Copyright (C) 2014 Savoir-faire Linux. All Rights Reserved.

--- a/hr_employee_firstname/tests/test_hr_employee_firstname.py
+++ b/hr_employee_firstname/tests/test_hr_employee_firstname.py
@@ -65,7 +65,7 @@ class TestEmployeeFirstname(TransactionCase):
         in firstname and lastname
         """
         # Check for employee10
-        self.assertEqual(self.employee10_id.firstname, "Jan")
+        self.assertEqual(self.employee10_id.firstname, 'Jan')
         self.assertEqual(self.employee10_id.lastname, 'Van-Eyck')
 
         # Check for employee20


### PR DESCRIPTION
Fix tests in hr_employee_firstname, pr's are falling by this, the method _get_inverse_name return a dict with string indexes, so the values updated on employees were all the time as 'firstname' and 'lastname' string, the indexes from the method, not the values.
