### PR TITLE
[hr_language][IMP] layout improvement

### DIFF
--- a/hr_language/views/hr_language_view.xml
+++ b/hr_language/views/hr_language_view.xml
@@ -8,7 +8,15 @@
         <field name="arch" type="xml">
             <notebook position="inside">
                 <page string="Languages" groups="base.group_hr_user">
-                    <field name="language_ids" nolabel="1" colspan="4"/>
+                    <field name="language_ids" nolabel="1" colspan="4">
+                        <tree string="Language" editable="bottom">
+                            <field name="name"/>
+                            <field name="description"/>
+                            <field name="can_read"/>
+                            <field name="can_write"/>
+                            <field name="can_speak"/>
+                        </tree>
+                    </field>
                 </page>
             </notebook>
         </field>
@@ -21,6 +29,7 @@
         <field name="model">hr.language</field>
         <field name="arch" type="xml">
             <tree string="Languages">
+                <field name="employee_id"/>
                 <field name="description"/>
                 <field name="can_read"/>
                 <field name="can_write"/>


### PR DESCRIPTION
Layout improvement. 

O2m language on employee form before:
![employee_language_5](https://cloud.githubusercontent.com/assets/1947376/12745038/fe67f8a8-c9c9-11e5-8c5e-b74d4222b0cf.png)

After:
![employee_language_3](https://cloud.githubusercontent.com/assets/1947376/12745045/08e29f22-c9ca-11e5-9c25-a5722ddb2366.png)

Before modification, after user click add an item on o2m language, Odoo will show employee language form:
![employee_language_2](https://cloud.githubusercontent.com/assets/1947376/12745081/29d0e482-c9ca-11e5-816a-233d134f2ee0.png)

After modification, users can add/edit employee language data through editable view:
![employee_language_4](https://cloud.githubusercontent.com/assets/1947376/12745133/66b1a896-c9ca-11e5-9ea5-58e4b3264fbe.png)
