### PR TITLE
[hr_language][8.0][IMP] Add language proficiency rating. Use simple header. Adjust README.rst

### DIFF
--- a/hr_language/README.rst
+++ b/hr_language/README.rst
@@ -1,10 +1,14 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
+===================
 Language Management
 ===================
 
-This module allows you to manage your employee languages.
+This module allows you to manage your employee languages proficiency.
+Language proficiency based on Interagency Language Roundtable (ILR)
+(http://www.govtilr.org/Skills/ILRscale1.htm)
 
 Usage
 =====
@@ -14,24 +18,44 @@ To use this module, you need to go to
 Languages are also available on the employee form
 (*Human Resources* / *Human Resources* / *Employees*).
 
-For further information, please visit:
 
- * https://www.odoo.com/forum/help-1
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/116/8.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/hr/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+hr/issues/new?body=module:%20
+hr_language%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------
 
 * Savoir-faire Linux (http://www.savoirfairelinux.com)
+* OpenSynergy Indonesia (https://opensynergy-indonesia.com)
 
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
@@ -39,4 +63,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/hr_language/__init__.py
+++ b/hr_language/__init__.py
@@ -1,22 +1,6 @@
-# -*- encoding: utf-8 -*-
-###############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2013 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
+# -*- coding: utf-8 -*-
+# © 2013 Savoir-faire Linux
+# © 2016 OpenSynergy Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/hr_language/__openerp__.py
+++ b/hr_language/__openerp__.py
@@ -1,27 +1,11 @@
-# -*- encoding: utf-8 -*-
-###############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2013 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
+# -*- coding: utf-8 -*-
+# © 2013 Savoir-faire Linux
+# © 2016 OpenSynergy Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Language Management",
-    "version": "8.0.0.1.0",
+    "version": "8.0.1.0.0",
     "category": "Human Resources",
     "license": "AGPL-3",
     "author": "Savoir-faire Linux,Odoo Community Association (OCA)",

--- a/hr_language/migrations/8.0.1.0.0/post-migration.py
+++ b/hr_language/migrations/8.0.1.0.0/post-migration.py
@@ -9,7 +9,7 @@ def migrate(cr, version):
         return
 
     cr.execute('''
-        UPDATE hr_language
+        UPDATE hr_language a
             SET
                 read_rating=(
                     CASE WHEN a.can_read IS TRUE THEN '3' ELSE '0' END),
@@ -17,7 +17,6 @@ def migrate(cr, version):
                     CASE WHEN a.can_speak IS TRUE THEN '3' ELSE '0' END),
                 write_rating=(
                     CASE WHEN a.can_write IS TRUE THEN '3' ELSE '0' END)
-        FROM    hr_language AS a
         ''')
 
     cr.execute("""

--- a/hr_language/migrations/8.0.1.0.0/post-migration.py
+++ b/hr_language/migrations/8.0.1.0.0/post-migration.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# © 2013 Savoir-faire Linux
+# © 2016 OpenSynergy Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    cr.execute('''
+        UPDATE hr_language
+            SET
+                read_rating=(
+                    CASE WHEN a.can_read IS TRUE THEN '3' ELSE '0' END),
+                speak_rating=(
+                    CASE WHEN a.can_speak IS TRUE THEN '3' ELSE '0' END),
+                write_rating=(
+                    CASE WHEN a.can_write IS TRUE THEN '3' ELSE '0' END)
+        FROM    hr_language AS a
+        ''')
+
+    cr.execute("""
+        DELETE FROM ir_model_data
+        WHERE   name = 'field_hr_language_can_read' AND
+                module = 'hr_language' AND
+                model = 'ir.model.fields'
+        """)
+
+    cr.execute("""
+        DELETE FROM ir_model_data
+        WHERE   name = 'field_hr_language_can_speak' AND
+                module = 'hr_language' AND
+                model = 'ir.model.fields'
+        """)
+
+    cr.execute("""
+        DELETE FROM ir_model_data
+        WHERE   name = 'field_hr_language_can_write' AND
+                module = 'hr_language' AND
+                model = 'ir.model.fields'
+        """)
+
+    cr.execute("""
+        DELETE FROM ir_model_fields AS a
+        USING    ir_model AS b
+        WHERE   a.name = 'can_read' AND
+                b.name = 'hr.language' AND
+                a.model_id = b.id
+        """)
+
+    cr.execute("""
+        DELETE FROM ir_model_fields AS a
+        USING    ir_model AS b
+        WHERE   a.name = 'can_speak' AND
+                b.name = 'hr.language' AND
+                a.model_id = b.id
+        """)
+
+    cr.execute("""
+        DELETE FROM ir_model_fields AS a
+        USING    ir_model AS b
+        WHERE   a.name = 'can_write' AND
+                b.name = 'hr.language' AND
+                a.model_id = b.id
+        """)
+
+    cr.execute("""
+        ALTER TABLE hr_language
+            DROP COLUMN IF EXISTS can_read
+            """)
+
+    cr.execute("""
+        ALTER TABLE hr_language
+            DROP COLUMN IF EXISTS can_speak
+            """)
+
+    cr.execute("""
+        ALTER TABLE hr_language
+            DROP COLUMN IF EXISTS can_write
+            """)

--- a/hr_language/migrations/8.0.1.0.0/pre-migration.py
+++ b/hr_language/migrations/8.0.1.0.0/pre-migration.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# © 2013 Savoir-faire Linux
+# © 2016 OpenSynergy Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+#
+#     cr.execute(
+#         'ALTER TABLE hr_language '
+#         'RENAME TO migration_hr_language')

--- a/hr_language/models/__init__.py
+++ b/hr_language/models/__init__.py
@@ -1,22 +1,6 @@
-# -*- encoding: utf-8 -*-
-###############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2013 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
+# -*- coding: utf-8 -*-
+# © 2013 Savoir-faire Linux
+# © 2016 OpenSynergy Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import hr_language

--- a/hr_language/models/hr_language.py
+++ b/hr_language/models/hr_language.py
@@ -1,45 +1,95 @@
-# -*- encoding: utf-8 -*-
-###############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2013 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
+# -*- coding: utf-8 -*-
+# © 2013 Savoir-faire Linux
+# © 2016 OpenSynergy Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import tools
 from openerp import models, fields
 
 
-class hr_language(models.Model):
+LANGUAGE_RATING = [
+    ('0', '0 - No Proficiency'),
+    ('0+', '0+ - Memorized Proficiency'),
+    ('1', '1 - Elementary Proficiency'),
+    ('1+', '1+ - Elementary Proficiency, Plus'),
+    ('2', '2 - Limited Working Proficiency'),
+    ('2+', '2+ - Limited Working Proficiency, Plus'),
+    ('3', '3 - General Professional Proficiency'),
+    ('3+', '3+ - General Professional Proficiency, Plus'),
+    ('4', '4 - Advance Professional Proficiency'),
+    ('4+', '4+ - Advance Professional Proficiency, Plus'),
+    ('5', '5 - Funcionally Native Proficiency'),
+]
+
+
+class HrLanguage(models.Model):
     _name = 'hr.language'
 
     name = fields.Selection(
         tools.scan_languages(),
-        string=u"Language", required=True)
+        string=u"Language",
+        required=True,
+    )
+
+    # NOT REQUIRED SINCE 8.0.1.0.0
     description = fields.Char(
-        string=u"Description", size=64, required=True)
+        string=u"Description",
+        required=False,
+    )
+
     employee_id = fields.Many2one(
-        'hr.employee', string=u"Employee", required=True)
-    can_read = fields.Boolean(u"Read", default=True, oldname='read')
-    can_write = fields.Boolean(u"Write", default=True, oldname='write')
-    can_speak = fields.Boolean(u"Speak", default=True, oldname='speak')
+        'hr.employee',
+        string=u"Employee",
+        required=True,
+    )
+
+    # DELETED SINCE 8.0.1.0.0
+    # can_read = fields.Boolean(
+    #     u"Read",
+    #     default=True,
+    #     oldname='read',
+    # )
+    # can_write = fields.Boolean(
+    #     u"Write",
+    #     default=True,
+    #     oldname='write',
+    # )
+    # can_speak = fields.Boolean(
+    #     u"Speak",
+    #     default=True,
+    #     oldname='speak',
+    # )
+    read_rating = fields.Selection(
+        string='Reading',
+        selection=LANGUAGE_RATING,
+        required=True,
+        default='0',
+    )
+    write_rating = fields.Selection(
+        string='Writing',
+        selection=LANGUAGE_RATING,
+        required=True,
+        default='0',
+    )
+    speak_rating = fields.Selection(
+        string='Speaking',
+        selection=LANGUAGE_RATING,
+        required=True,
+        default='0',
+    )
+    listen_rating = fields.Selection(
+        string='Listening',
+        selection=LANGUAGE_RATING,
+        required=True,
+        default='0',
+    )
 
 
-class hr_employee(models.Model):
+class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
     language_ids = fields.One2many(
-        'hr.language', 'employee_id', u"Languages")
+        'hr.language',
+        'employee_id',
+        u"Languages",
+    )

--- a/hr_language/views/hr_language_view.xml
+++ b/hr_language/views/hr_language_view.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- © 2013 Savoir-faire Linux
+     © 2016 OpenSynergy Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
 <openerp>
   <data>
     <!-- Employee -->
@@ -11,10 +15,12 @@
                     <field name="language_ids" nolabel="1" colspan="4">
                         <tree string="Language" editable="bottom">
                             <field name="name"/>
+                            <field name="employee_id"/>
+                            <field name="read_rating"/>
+                            <field name="speak_rating"/>
+                            <field name="listen_rating"/>
+                            <field name="write_rating"/>
                             <field name="description"/>
-                            <field name="can_read"/>
-                            <field name="can_write"/>
-                            <field name="can_speak"/>
                         </tree>
                     </field>
                 </page>
@@ -30,10 +36,12 @@
         <field name="arch" type="xml">
             <tree string="Languages">
                 <field name="employee_id"/>
+                <field name="employee_id"/>
+                <field name="read_rating"/>
+                <field name="speak_rating"/>
+                <field name="listen_rating"/>
+                <field name="write_rating"/>
                 <field name="description"/>
-                <field name="can_read"/>
-                <field name="can_write"/>
-                <field name="can_speak"/>
             </tree>
         </field>
     </record>
@@ -44,16 +52,14 @@
         <field name="arch" type="xml">
             <form string="Language">
                 <sheet>
-                    <group>
+                    <group name="main" colspan="4">
                         <field name="name"/>
-                        <field name="description"/>
                         <field name="employee_id"/>
-                        <newline/>
-                        <field name="can_read"/>
-                        <newline/>
-                        <field name="can_write"/>
-                        <newline/>
-                        <field name="can_speak"/>
+                        <field name="read_rating"/>
+                        <field name="speak_rating"/>
+                        <field name="listen_rating"/>
+                        <field name="write_rating"/>
+                        <field name="description"/>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
Improvements/Changes:
1. Add language proficiency rating based on ILS (interagency language roundtable) http://www.govtilr.org/Skills/ILRscale1.htm
2. Make _description_ field non-required
3. Use simple header
4. Adjust README.rst according latest OCA template

Note:
- version bump from 8.0.0.1.0 into 8.0.1.1.0
# Screenshot
## Language Tab on Employee Form

![selection_3](https://cloud.githubusercontent.com/assets/1947376/14045877/41498068-f2d0-11e5-9a5f-05378d896af4.png)
## Tree Language

![selection_1](https://cloud.githubusercontent.com/assets/1947376/14045903/57dbd9de-f2d0-11e5-8e66-9d4529318b4a.png)
## Form Language

![selection_2](https://cloud.githubusercontent.com/assets/1947376/14045923/70981bd6-f2d0-11e5-8be2-f7222e98f221.png)
