### PR TITLE
[FIX] Fix issue with 2 invoices on the same partner and the same total amount

### DIFF
--- a/hr_expense_invoice/models/hr_expense_expense.py
+++ b/hr_expense_invoice/models/hr_expense_expense.py
@@ -40,7 +40,10 @@ class HrExpenseExpense(models.Model):
                     move_lines = expense.account_move_id.line_id
                     c_move_lines = move_lines.filtered(
                         lambda x: x.partner_id == partner and
-                        x.debit == line.invoice.residual)
+                        x.debit == line.invoice.residual and
+                        not x.reconcile_id)
+                    if len(c_move_lines) > 1:
+                        c_move_lines = c_move_lines[0]
                     c_move_lines |= line.invoice.move_id.line_id.filtered(
                         lambda x: x.account_id == line.invoice.account_id and
                         x.credit == line.invoice.residual)


### PR DESCRIPTION
On the same expense, when we have 2 or more lines with differents invoices, and each invoices have the same total amount, reconcile is not possible.

The fix is to exclude reconcile account.move.line, and the first time if we have more than one line to reconcile on the same amount, we keep the first.
