### PR TITLE
[ADD]hr_payroll_cancel from @vauxoo

### DIFF
--- a/hr_payroll_cancel/__init__.py
+++ b/hr_payroll_cancel/__init__.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+###########################################################################
+#    Module Writen to OpenERP, Open Source Management Solution
+#
+#    Copyright (c) 2014 Vauxoo - http://www.vauxoo.com/
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+############################################################################
+#    Coded by: Luis Torres (luis_t@vauxoo.com)
+############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################

--- a/hr_payroll_cancel/__openerp__.py
+++ b/hr_payroll_cancel/__openerp__.py
@@ -1,0 +1,52 @@
+# -*- encoding: utf-8 -*-
+###########################################################################
+#    Module Writen to OpenERP, Open Source Management Solution
+#
+#    Copyright (c) 2014 Vauxoo - http://www.vauxoo.com/
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+############################################################################
+#    Coded by: Luis Torres (luis_t@vauxoo.com)
+############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Hr Payroll Cancel", 
+    "version": "1.0", 
+    "author": "Vauxoo", 
+    "category": "Localization/Mexico", 
+    "description": """
+    This module change the workflow from hr.payslip to can cancel after to confirm this
+    """, 
+    "website": "http://www.vauxoo.com/", 
+    "license": "AGPL-3", 
+    "depends": [
+        "hr_payroll"
+    ], 
+    "demo": [], 
+    "data": [
+        "hr_payslip_view.xml", 
+        "hr_payslip_workflow.xml", 
+        "test/update_payroll_workflow.yml"
+    ], 
+    "test": [], 
+    "js": [], 
+    "css": [], 
+    "qweb": [], 
+    "installable": True, 
+    "auto_install": False, 
+    "active": False
+}

--- a/hr_payroll_cancel/hr_payslip_view.xml
+++ b/hr_payroll_cancel/hr_payslip_view.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<openerp>
+    <data>
+
+        <record id="view_cancel_payslip_form" model="ir.ui.view">
+                <field name="name">view.cancel.payslip.form</field>
+                <field name="model">hr.payslip</field>     
+                <field name="inherit_id" ref="hr_payroll.view_hr_payslip_form"/>
+                <field name="arch" type="xml">
+                    <xpath expr="//button[@string='Cancel Payslip']" position="attributes">
+                        <attribute name="states">draft,hr_check,confirm,verify,done</attribute>
+                    </xpath>
+                </field>
+        </record>
+
+    </data>
+</openerp>

--- a/hr_payroll_cancel/hr_payslip_workflow.xml
+++ b/hr_payroll_cancel/hr_payslip_workflow.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+    <data>
+        <record id="hr_payroll.act_done" model="workflow.activity">
+            <field name="wkf_id" ref="hr_payroll.wkf"/>
+            <field name="name">done</field>
+            <field name="action">process_sheet()</field>
+            <field name="kind">function</field>
+            <field name="flow_stop"/>
+        </record>
+        
+        <record id="workflow_transition_act_done_to_act_cancel" model="workflow.transition">
+            <field name="signal">cancel_sheet</field>
+            <field name="act_from" ref="hr_payroll.act_done"/>
+            <field name="act_to" ref="hr_payroll.act_cancel"/>
+            <field name="condition">True</field>
+        </record>
+        
+    </data>
+</openerp>

--- a/hr_payroll_cancel/i18n/es.po
+++ b/hr_payroll_cancel/i18n/es.po
@@ -1,0 +1,21 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-07-04 17:34+0000\n"
+"PO-Revision-Date: 2014-07-04 17:34+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_payroll_cancel
+#: view:hr.payslip:0
+msgid "draft,hr_check,confirm,verify,done"
+msgstr "draft,hr_check,confirm,verify,done"
+

--- a/hr_payroll_cancel/i18n/es_MX.po
+++ b/hr_payroll_cancel/i18n/es_MX.po
@@ -1,0 +1,21 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-07-04 17:34+0000\n"
+"PO-Revision-Date: 2014-07-04 17:34+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_payroll_cancel
+#: view:hr.payslip:0
+msgid "draft,hr_check,confirm,verify,done"
+msgstr "draft,hr_check,confirm,verify,done"
+

--- a/hr_payroll_cancel/test/update_payroll_workflow.yml
+++ b/hr_payroll_cancel/test/update_payroll_workflow.yml
@@ -1,0 +1,8 @@
+-
+  Workflow Mexican Electronic Payroll
+-
+  !python {model: hr.payslip}: |
+    cr.execute("""UPDATE wkf_instance
+                SET state = 'active'
+                WHERE state = 'complete' and wkf_id = (SELECT id FROM wkf WHERE name = 'hr.payslip.basic')
+                AND res_id IN (SELECT id FROM hr_payslip WHERE state = 'done')""")


### PR DESCRIPTION
## Cancel a payslip

This module introduces the following features:
- The module payroll_cancel allows the user to cancel a payslip whatever the previous state is.
### Installation

No special needs.
### Configuration

No extra configuration needed.
### Usage
1. Go to the payslip list and select the one you want to cancel.
2. Click on the button "Cancel payslip". The payslip is now rejected. 
3. To accept this payslip again, click on "set to draft" button.

If there’s a refund for a payslip the user should not cancel the entry because the refund would still be confirm. In that case, the user have either to confirm again the payslip or cancel the refund.
