### PR TITLE
[9.0][ADD] Module 'hr_holidays_leave_auto_approve':

### DIFF
--- a/hr_holidays_leave_auto_approve/README.rst
+++ b/hr_holidays_leave_auto_approve/README.rst
@@ -1,0 +1,45 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================
+Auto Approve Leaves
+===================
+
+This module allows the user to define a leave type in order to make the system
+automatically approving all the leave requests (and leave allocation requests)
+belonging to that leave type.
+
+Configuration
+=============
+
+If you wish that the system automatically approves all the leave requests
+belonging to a specific leave type, please follow the steps below.
+
+#. Go on the leave type configuration menu
+#. Select the leave type you wish to setup
+#. Mark the flag 'Auto Approve'.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Andrea Stirpe <a.stirpe@onestein.nl>
+* Antonio Esposito <a.esposito@onestein.nl>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/hr_holidays_leave_auto_approve/__init__.py
+++ b/hr_holidays_leave_auto_approve/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/hr_holidays_leave_auto_approve/__openerp__.py
+++ b/hr_holidays_leave_auto_approve/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Auto Approve Leaves',
+    'version': '9.0.1.0.0',
+    'license': 'AGPL-3',
+    'summary': '''Leave type for auto approval of Leaves''',
+    'author': 'ONESTEiN BV, Odoo Community Association (OCA)',
+    'website': 'http://www.onestein.eu',
+    'category': 'Human Resources',
+    'depends': [
+        'hr_holidays',
+    ],
+    'data': [
+        'views/hr_holidays_status.xml',
+    ],
+    'installable': True,
+}

--- a/hr_holidays_leave_auto_approve/models/__init__.py
+++ b/hr_holidays_leave_auto_approve/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import hr_holidays
+from . import hr_holidays_status

--- a/hr_holidays_leave_auto_approve/models/hr_holidays.py
+++ b/hr_holidays_leave_auto_approve/models/hr_holidays.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api
+
+
+class HrHolidays(models.Model):
+    _inherit = "hr.holidays"
+
+    @api.model
+    def _check_state_access_right(self, vals):
+        if self.env['res.users'].browse(self.env.uid)._is_admin():
+            return True
+        return super(HrHolidays, self)._check_state_access_right(vals)
+
+    @api.model
+    @api.returns('self', lambda value: value.id)
+    def create(self, values):
+        result = super(HrHolidays, self).create(values)
+        if result.holiday_status_id.auto_approve:
+            result.sudo().signal_workflow('validate')
+        return result

--- a/hr_holidays_leave_auto_approve/models/hr_holidays_status.py
+++ b/hr_holidays_leave_auto_approve/models/hr_holidays_status.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields
+
+
+class HrHolidaysStatus(models.Model):
+    _inherit = "hr.holidays.status"
+
+    auto_approve = fields.Boolean(
+        string='Auto Approve',
+        help="If True, leaves belonging to this leave type will be"
+             " automatically approved")

--- a/hr_holidays_leave_auto_approve/tests/__init__.py
+++ b/hr_holidays_leave_auto_approve/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_hr_holidays_leave_auto_approve

--- a/hr_holidays_leave_auto_approve/tests/test_hr_holidays_leave_auto_approve.py
+++ b/hr_holidays_leave_auto_approve/tests/test_hr_holidays_leave_auto_approve.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from datetime import datetime, timedelta
+from openerp.tests.common import TransactionCase
+from openerp.tools import DEFAULT_SERVER_DATE_FORMAT as DF
+
+
+class TestHolidaysAutoApprove(TransactionCase):
+    def setUp(self):
+        super(TestHolidaysAutoApprove, self).setUp()
+        self.employee_model = self.env['hr.employee']
+        self.user_model = self.env['res.users']
+        self.leave_type_model = self.env['hr.holidays.status']
+        self.leave_request_model = self.env['hr.holidays']
+
+        # Create an employee user to make leave requests
+        self.test_user_id = self.user_model.create({
+            'name': 'Test User',
+            'login': 'test_user',
+            'email': 'mymail@test.com'
+        })
+
+        # Create an employee related to the user to make leave requests
+        self.test_employee_id = self.employee_model.create(
+            {'name': 'Test Employee', 'user_id': self.test_user_id.id})
+
+        # Create 2 leave type
+        self.test_leave_type1_id = self.leave_type_model.create(
+            {'name': 'Test Leave Type1', 'auto_approve': True})
+        self.test_leave_type2_id = self.leave_type_model.create(
+            {'name': 'Test Leave Type2', 'auto_approve': False})
+
+        # Create leave allocation requests for Test Leave Type1 and 2
+        self.leave_allocation1 = self.leave_request_model.create({
+            'name': 'Test Allocation Request 1',
+            'holiday_status_id': self.test_leave_type1_id.id,
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'number_of_days_temp': 10,
+            'type': 'add',
+        })
+
+        self.leave_allocation2 = self.leave_request_model.create({
+            'name': 'Test Allocation Request 2',
+            'holiday_status_id': self.test_leave_type2_id.id,
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'number_of_days_temp': 10,
+            'type': 'add',
+        })
+
+    def test_allocation_requests_state(self):
+        # Check for leave_allocation1 state
+        self.assertEqual(self.leave_allocation1.state, 'validate')
+
+        # Check for leave_allocation2 state
+        self.assertEqual(self.leave_allocation2.state, 'confirm')
+
+    def test_leave_requests_state(self):
+
+        # Validate the leave_allocation2
+        self.leave_allocation2.signal_workflow('validate')
+
+        # Check for leave_allocation2 state
+        self.assertEqual(self.leave_allocation2.state, 'validate')
+
+        today = datetime.today()
+
+        # Create leave requests for Leave Type1 and 2
+        leave1 = self.leave_request_model.create({
+            'name': 'Test Leave Request 1',
+            'holiday_status_id': self.test_leave_type1_id.id,
+            'date_from': today.strftime(DF),
+            'date_to': (today + timedelta(days=2)).strftime(DF),
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+        })
+
+        leave2 = self.leave_request_model.create({
+            'name': 'Test Leave Request 2',
+            'holiday_status_id': self.test_leave_type2_id.id,
+            'date_from': (today + timedelta(days=4)).strftime(DF),
+            'date_to': (today + timedelta(days=8)).strftime(DF),
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+        })
+
+        # Check for leave1 state
+        self.assertEqual(leave1.state, 'validate')
+
+        # Check for leave2 state
+        self.assertEqual(leave2.state, 'confirm')
+
+    def test_leave_requests_state_employee_user(self):
+
+        today = datetime.today()
+
+        # Create leave requests for Leave Type1 and 2
+        leave1 = self.leave_request_model.sudo(self.test_user_id).create({
+            'name': 'Test Leave Request 1',
+            'holiday_status_id': self.test_leave_type1_id.id,
+            'date_from': (today + timedelta(days=10)).strftime(DF),
+            'date_to': (today + timedelta(days=12)).strftime(DF),
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+        })
+
+        leave2 = self.leave_request_model.sudo(self.test_user_id).create({
+            'name': 'Test Leave Request 2',
+            'holiday_status_id': self.test_leave_type2_id.id,
+            'holiday_type': 'employee',
+            'date_from': (today + timedelta(days=13)).strftime(DF),
+            'date_to': (today + timedelta(days=14)).strftime(DF),
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+        })
+
+        # Check for leave1 state
+        self.assertEqual(leave1.state, 'validate')
+
+        # Check for leave2 state
+        self.assertEqual(leave2.state, 'confirm')

--- a/hr_holidays_leave_auto_approve/views/hr_holidays_status.xml
+++ b/hr_holidays_leave_auto_approve/views/hr_holidays_status.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_holiday_status_form_auto_approve" model="ir.ui.view">
+        <field name="name">hr.holidays.status.form.auto.approve</field>
+        <field name="model">hr.holidays.status</field>
+        <field name="inherit_id" ref="hr_holidays.edit_holiday_status_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='limit']" position="after">
+                <field name="auto_approve"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module allows the user to define a leave type in order to make the system
automatically approving all the leave requests (and leave allocation requests)
belonging to that leave type.
