### PR TITLE
[FIX] hr_holidays_legal_leave: @api.depends of is_annual

### DIFF
--- a/hr_holidays_legal_leave/models/hr_holidays_status.py
+++ b/hr_holidays_legal_leave/models/hr_holidays_status.py
@@ -23,7 +23,7 @@ class HolidaysType(models.Model):
     def _get_default_company(self):
         return self.env.user.company_id.id
 
-    @api.depends('company_id', 'is_annual')
+    @api.depends('company_id')
     def _compute_is_annual(self):
         for rec in self:
             rec.is_annual = rec.company_id.legal_holidays_status_id == rec.id


### PR DESCRIPTION
Commit 00f4e3d seems causing a warning on runbot:

```
resolve_deps Field hr.holidays.status.is_annual depends on itself; please fix its decorator @api.depends(). 
```

Fixes #273
