### PR TITLE
[7.0] [FIX] [hr_period] Typo & Pylint

### DIFF
--- a/hr_period/models/hr_fiscal_year.py
+++ b/hr_period/models/hr_fiscal_year.py
@@ -19,6 +19,10 @@
 #
 ##############################################################################
 
+from dateutil.relativedelta import relativedelta
+
+from itertools import chain
+
 from openerp.osv import orm, fields
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
 from openerp.tools.translate import _
@@ -26,14 +30,11 @@ from openerp.tools.translate import _
 from datetime import datetime
 strftime = datetime.strptime
 
-from dateutil.relativedelta import relativedelta
-
-from itertools import chain
 
 INTERVALS = {
     'annually': (relativedelta(months=12), 1),
     'semi-annually': (relativedelta(months=6), 2),
-    'quaterly': (relativedelta(months=3), 4),
+    'quarterly': (relativedelta(months=3), 4),
     'bi-monthly': (relativedelta(months=2), 6),
     'monthly': (relativedelta(months=1), 12),
     'bi-weekly': (relativedelta(weeks=2), 26),


### PR DESCRIPTION
Generates KeyError when tried to create periods from the fiscal year when schedule/Intervals set as Quarterly because of the typo

And set the module level import at top of file (pylint)

cc @jbeficent 

KeyError is shown below 

> 2017-01-17 12:49:26,623 9634 ERROR hr_timesheet_sheet_period_v7_test_cases openerp.netsvc: quarterly
Traceback (most recent call last):
  File "/home/serpentcs/workspace/openerp/7.0/server/openerp/netsvc.py", line 292, in dispatch_rpc
    result = ExportService.getService(service_name).dispatch(method, params)
  File "/home/serpentcs/workspace/openerp/7.0/server/openerp/service/web_services.py", line 626, in dispatch
    res = fn(db, uid, *params)
  File "/home/serpentcs/workspace/openerp/7.0/server/openerp/osv/osv.py", line 190, in execute_kw
    return self.execute(db, uid, obj, method, *args, **kw or {})
  File "/home/serpentcs/workspace/openerp/7.0/server/openerp/osv/osv.py", line 132, in wrapper
    return f(self, dbname, *args, **kwargs)
  File "/home/serpentcs/workspace/openerp/7.0/server/openerp/osv/osv.py", line 199, in execute
    res = self.execute_cr(cr, uid, obj, method, *args, **kw)
  File "/home/serpentcs/workspace/openerp/7.0/server/openerp/osv/osv.py", line 187, in execute_cr
    return getattr(object, method)(cr, uid, *args, **kw)
  File "/home/serpentcs/workspace/openerp/project_7/7.0-hr-darshan/hr_period/models/hr_fiscal_year.py", line 210, in create_periods
    delta, nb_periods = INTERVALS[fy.schedule_pay]
KeyError: u'quarterly'

