### PR TITLE
[10.0][ADD] hr_holidays_imposed_days

### DIFF
--- a/hr_holidays_imposed_days/README.rst
+++ b/hr_holidays_imposed_days/README.rst
@@ -6,11 +6,11 @@
 Imposed holidays
 ================
 
-Allows to manage imposed holidays. 
+Allows to manage imposed holidays.
 
 This can be used to manage periods where the company is closed for everyone,
-such as end of year celebration. The HR team can use this to easily create 
-and validate vacations for all the employees of a company. 
+such as end of year celebration. The HR team can use this to easily create
+and validate vacations for all the employees of a company.
 
 Installation
 ============
@@ -28,7 +28,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/116/9.0
+   :target: https://runbot.odoo-community.org/runbot/116/10.0
 
 Bug Tracker
 ===========
@@ -50,6 +50,7 @@ Contributors
 ------------
 
 * Damien Crier <damien.crier@camptocamp.com>
+* Denis Leemann <denis.leemann@camptocamp.com>
 
 Maintainer
 ----------

--- a/hr_holidays_imposed_days/README.rst
+++ b/hr_holidays_imposed_days/README.rst
@@ -1,0 +1,67 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+================
+Imposed holidays
+================
+
+Allows to manage imposed holidays. 
+
+This can be used to manage periods where the company is closed for everyone,
+such as end of year celebration. The HR team can use this to easily create 
+and validate vacations for all the employees of a company. 
+
+Installation
+============
+
+No additional steps necessary.
+
+Configuration
+=============
+
+Go to ``Leaves > Imposed Days`` menu and specify the date of the imposed days
+as well as the holidays type.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/116/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/hr/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Damien Crier <damien.crier@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/hr_holidays_imposed_days/__init__.py
+++ b/hr_holidays_imposed_days/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Author: Damien Crier
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/hr_holidays_imposed_days/__init__.py
+++ b/hr_holidays_imposed_days/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# Author: Damien Crier
-# Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/hr_holidays_imposed_days/__manifest__.py
+++ b/hr_holidays_imposed_days/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Imposed holidays days',
-    'version': '9.0.1.0.0',
+    'version': '10.0.1.0.0',
     'category': 'Human Resources',
     'license': 'AGPL-3',
     'author': 'Camptocamp SA, '

--- a/hr_holidays_imposed_days/__openerp__.py
+++ b/hr_holidays_imposed_days/__openerp__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Author: Damien Crier
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'Imposed holidays days',
+    'version': '9.0.1.0.0',
+    'category': 'Human Resources',
+    'license': 'AGPL-3',
+    'author': 'Camptocamp SA, '
+              'Odoo Community Association (OCA)',
+    'website': 'http://www.camptocamp.com',
+    'depends': ['hr_holidays'],
+    'data': ['views/imposed_days.xml',
+             'security/ir.model.access.csv',
+             ],
+    'installable': True,
+}

--- a/hr_holidays_imposed_days/models/__init__.py
+++ b/hr_holidays_imposed_days/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Author: Damien Crier
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import hr_imposed_holidays
+from . import hr_employee

--- a/hr_holidays_imposed_days/models/__init__.py
+++ b/hr_holidays_imposed_days/models/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# Author: Damien Crier
-# Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import hr_imposed_holidays

--- a/hr_holidays_imposed_days/models/hr_employee.py
+++ b/hr_holidays_imposed_days/models/hr_employee.py
@@ -27,7 +27,6 @@ class HrEmployee(models.Model):
         imposed = imposed_holiday.search(
             self._get_search_imposed_parameters(emp)
             )
-
         for imposed_day in imposed:
             created = holiday.create({
                 'number_of_days_temp': 1.,
@@ -39,6 +38,6 @@ class HrEmployee(models.Model):
                 'holiday_status_id': imposed_day.status_id.id,
                 })
             if imposed_day.auto_confirm:
-                created.signal_workflow('validate')
+                created.action_validate()
 
         return emp

--- a/hr_holidays_imposed_days/models/hr_employee.py
+++ b/hr_holidays_imposed_days/models/hr_employee.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
-# Author: Damien Crier
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, api, fields
+from odoo import models, api, fields
 
 
 class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
     def _get_search_imposed_parameters(self, employee):
-        """ """
         res = [('company_id', '=', employee.company_id.id),
                ('employee_ids', '=', False),  # no employee defined means all
                ('date_from', '>=', fields.Datetime.now())

--- a/hr_holidays_imposed_days/models/hr_employee.py
+++ b/hr_holidays_imposed_days/models/hr_employee.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Author: Damien Crier
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api, fields
+
+
+class HrEmployee(models.Model):
+    _inherit = 'hr.employee'
+
+    def _get_search_imposed_parameters(self, employee):
+        """ """
+        res = [('company_id', '=', employee.company_id.id),
+               ('employee_ids', '=', False),  # no employee defined means all
+               ('date_from', '>=', fields.Datetime.now())
+               ]
+        return res
+
+    @api.model
+    @api.returns('self', lambda value: value.id)
+    def create(self, values):
+        """ add imposed days if a configuration exists """
+        imposed_holiday = self.env['hr.holidays.imposed']
+        holiday = self.env['hr.holidays']
+
+        emp = super(HrEmployee, self).create(values)
+
+        imposed = imposed_holiday.search(
+            self._get_search_imposed_parameters(emp)
+            )
+
+        for imposed_day in imposed:
+            created = holiday.create({
+                'number_of_days_temp': 1.,
+                'name': imposed_day.name,
+                'date_from': imposed_day.date_from,
+                'date_to': imposed_day.date_to,
+                'employee_id': emp.id,
+                'type': 'remove',
+                'holiday_status_id': imposed_day.status_id.id,
+                })
+            if imposed_day.auto_confirm:
+                created.signal_workflow('validate')
+
+        return emp

--- a/hr_holidays_imposed_days/models/hr_imposed_holidays.py
+++ b/hr_holidays_imposed_days/models/hr_imposed_holidays.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+# Author: Damien Crier
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import datetime
+import math
+
+from openerp import models, fields, api, exceptions, _
+from openerp import tools
+
+
+class HrHolidaysImposed(models.Model):
+    _name = 'hr.holidays.imposed'
+    _description = 'Manage imposed holidays'
+
+    name = fields.Char(required=True)
+    date_from = fields.Datetime(required=True)
+    date_to = fields.Datetime(required=True)
+    number_of_days = fields.Float()
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        string="Company",
+        default=lambda self: self.env['res.company']._company_default_get(
+            'hr.holidays.imposed')
+    )
+    status_id = fields.Many2one(
+        comodel_name='hr.holidays.status',
+        string="Leave type",
+        required=True
+    )
+    employee_ids = fields.Many2many(comodel_name='hr.employee',
+                                    help="If empty, all employees of the "
+                                         "company will have this day/period "
+                                         "imposed")
+    auto_confirm = fields.Boolean()
+
+    @api.multi
+    def validate(self):
+        for rec in self:
+            created = self.env['hr.holidays']
+            if rec.employee_ids:
+                employees = rec.employee_ids
+            else:
+                employees = self.env['hr.employee'].search(
+                    [('company_id', '=', rec.company_id.id)])
+
+            for employee in employees:
+                vals = {
+                    'name': rec.name,
+                    'date_from': rec.date_from,
+                    'date_to': rec.date_to,
+                    'employee_id': employee.id,
+                    'type': 'remove',
+                    'holiday_status_id': rec.status_id.id,
+                }
+                leave = created.create(vals)
+                res = leave.onchange_date_from(rec.date_to, rec.date_from,)
+                leave.write(res['value'])
+                created |= leave
+            if rec.auto_confirm:
+                created.signal_workflow('validate')
+
+    def _get_number_of_days(self, date_from, date_to):
+        """Returns a float equals to the timedelta between
+           two dates given as string."""
+
+        from_dt = fields.Datetime.from_string(date_from)
+        to_dt = fields.Datetime.from_string(date_to)
+        timedelta = to_dt - from_dt
+        diff_day = timedelta.days + float(timedelta.seconds) / 86400
+        return diff_day
+
+    @api.onchange('date_from', 'date_to')
+    def onchange_dates(self):
+        """
+        If there are no date set for date_to, automatically set one
+        8 hours later than the date_from.
+        Also update the number_of_days.
+        """
+        # date_to has to be greater than date_from
+        if ((self.date_from and self.date_to) and
+                (self.date_from > self.date_to)):
+            raise exceptions.Warning(
+                _('The start date must be anterior to the end date.'))
+
+        # No date_to set so far: automatically compute one 8 hours later
+        if self.date_from and not self.date_to:
+            date_to_with_delta = datetime.datetime.strptime(
+                self.date_from,
+                tools.DEFAULT_SERVER_DATETIME_FORMAT) + datetime.timedelta(
+                hours=8)
+            self.date_to = str(date_to_with_delta)
+
+        # Compute and update the number of days
+        if ((self.date_to and self.date_from) and
+                (self.date_from <= self.date_to)):
+            diff_day = self._get_number_of_days(self.date_from, self.date_to)
+            self.number_of_days = self.compute_nb_days(diff_day)
+        else:
+            self.number_of_days = 0
+
+    def compute_nb_days(self, diff):
+        return round(math.floor(diff))+1

--- a/hr_holidays_imposed_days/models/hr_imposed_holidays.py
+++ b/hr_holidays_imposed_days/models/hr_imposed_holidays.py
@@ -6,8 +6,8 @@
 import datetime
 import math
 
-from openerp import models, fields, api, exceptions, _
-from openerp import tools
+from odoo import models, fields, api, exceptions, _
+from odoo import tools
 
 
 class HrHolidaysImposed(models.Model):

--- a/hr_holidays_imposed_days/models/hr_imposed_holidays.py
+++ b/hr_holidays_imposed_days/models/hr_imposed_holidays.py
@@ -55,11 +55,10 @@ class HrHolidaysImposed(models.Model):
                     'holiday_status_id': rec.status_id.id,
                 }
                 leave = created.create(vals)
-                res = leave.onchange_date_from(rec.date_to, rec.date_from,)
-                leave.write(res['value'])
+                leave._onchange_date_from()
                 created |= leave
             if rec.auto_confirm:
-                created.signal_workflow('validate')
+                created.action_validate()
 
     def _get_number_of_days(self, date_from, date_to):
         """Returns a float equals to the timedelta between

--- a/hr_holidays_imposed_days/models/hr_imposed_holidays.py
+++ b/hr_holidays_imposed_days/models/hr_imposed_holidays.py
@@ -77,6 +77,16 @@ class HrHolidaysImposed(models.Model):
         8 hours later than the date_from.
         Also update the number_of_days.
         """
+        # Beacause when setting date_from, date_to is setted to actual day and
+        # will trigger an error.
+        if not self.id and self.date_from and \
+           self.date_to is False or self.date_from > self.date_to:
+            date_to_with_delta = datetime.datetime.strptime(
+                self.date_from,
+                tools.DEFAULT_SERVER_DATETIME_FORMAT) + datetime.timedelta(
+                hours=8)
+            self.date_to = str(date_to_with_delta)
+
         # date_to has to be greater than date_from
         if ((self.date_from and self.date_to) and
                 (self.date_from > self.date_to)):

--- a/hr_holidays_imposed_days/models/hr_imposed_holidays.py
+++ b/hr_holidays_imposed_days/models/hr_imposed_holidays.py
@@ -6,6 +6,7 @@
 import datetime
 import math
 
+from odoo.exceptions import ValidationError
 from odoo import models, fields, api, exceptions, _
 from odoo import tools
 
@@ -111,3 +112,11 @@ class HrHolidaysImposed(models.Model):
 
     def compute_nb_days(self, diff):
         return round(math.floor(diff))+1
+
+    @api.one
+    @api.constrains('date_from', 'date_to')
+    def _check_dates(self):
+        if ((self.date_from and self.date_to) and
+                (self.date_from > self.date_to)):
+            raise ValidationError(_(
+                "The start date must be anterior to the end date."))

--- a/hr_holidays_imposed_days/security/ir.model.access.csv
+++ b/hr_holidays_imposed_days/security/ir.model.access.csv
@@ -1,4 +1,4 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_hr_holidays_imposed_user","hr.holidays.imposed_user","model_hr_holidays_imposed","base.group_user",1,0,0,0
-"access_hr_holidays_imposed_manager","hr.holidays.imposed_manager","model_hr_holidays_imposed","base.group_hr_manager",1,1,1,1
+"access_hr_holidays_imposed_manager","hr.holidays.imposed_manager","model_hr_holidays_imposed","hr.group_hr_manager",1,1,1,1
 

--- a/hr_holidays_imposed_days/security/ir.model.access.csv
+++ b/hr_holidays_imposed_days/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_hr_holidays_imposed_user","hr.holidays.imposed_user","model_hr_holidays_imposed","base.group_user",1,0,0,0
+"access_hr_holidays_imposed_manager","hr.holidays.imposed_manager","model_hr_holidays_imposed","base.group_hr_manager",1,1,1,1
+

--- a/hr_holidays_imposed_days/tests/__init__.py
+++ b/hr_holidays_imposed_days/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Author: Damien Crier
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_holidays_imposed_days

--- a/hr_holidays_imposed_days/tests/__init__.py
+++ b/hr_holidays_imposed_days/tests/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# Author: Damien Crier
-# Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_holidays_imposed_days

--- a/hr_holidays_imposed_days/tests/test_holidays_imposed_days.py
+++ b/hr_holidays_imposed_days/tests/test_holidays_imposed_days.py
@@ -3,8 +3,8 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp.tests import common
-from openerp import fields
+from odoo.tests import common
+from odoo import fields
 from dateutil.relativedelta import relativedelta
 
 

--- a/hr_holidays_imposed_days/tests/test_holidays_imposed_days.py
+++ b/hr_holidays_imposed_days/tests/test_holidays_imposed_days.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+# Author: Damien Crier
+# Copyright 2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests import common
+from openerp import fields
+from dateutil.relativedelta import relativedelta
+
+
+class TestHolidaysImposedDays(common.TransactionCase):
+
+    def setUp(self):
+        super(TestHolidaysImposedDays, self).setUp()
+        self.employee_model = self.env['hr.employee']
+        self.holiday_status_model = self.env['hr.holidays.status']
+        self.holiday_imposed_model = self.env['hr.holidays.imposed']
+        self.holiday_model = self.env['hr.holidays']
+
+        # create leave types that we will be manupilating
+        self.holiday_type = self.holiday_status_model.create(
+            {
+                'name': 'Leave',
+                'limit': True
+            }
+        )
+
+        self.today = fields.Datetime.from_string(fields.Datetime.now())
+
+    def test_imposed_number_of_days_computation(self):
+        # define an imposed day
+        self.imposed = self.holiday_imposed_model.create(
+            {'name': 'TEST',
+             'date_from': fields.Datetime.to_string(self.today +
+                                                    relativedelta(days=2)),
+             'date_to': fields.Datetime.to_string(self.today +
+                                                  relativedelta(days=4)),
+             'status_id': self.holiday_type.id,
+             }
+            )
+        self.imposed.onchange_dates()
+        self.assertEqual(self.imposed.number_of_days, 3.)
+
+    def test_imposed_employee_create(self):
+        # Create employee
+        self.employee = self.employee_model.create({
+            'name': 'Employee 1',
+        })
+        leaves = self.holiday_model.search(
+            [('type', '=', 'remove'),
+             ('employee_id', '=', self.employee.id)
+             ]
+        )
+        self.assertEqual(len(leaves), 0)
+
+        self.imposed = self.holiday_imposed_model.create(
+            {'name': 'TEST',
+             'date_from': fields.Datetime.to_string(self.today +
+                                                    relativedelta(days=2)),
+             'date_to': fields.Datetime.to_string(self.today +
+                                                  relativedelta(days=4)),
+             'status_id': self.holiday_type.id,
+             }
+            )
+        self.employee2 = self.employee_model.create({
+            'name': 'Employee 2',
+        })
+        leaves = self.holiday_model.search(
+            [('type', '=', 'remove'),
+             ('employee_id', '=', self.employee2.id)
+             ]
+        )
+        self.assertEqual(len(leaves), 1)
+        self.assertEqual(leaves[0].state, 'confirm')
+
+    def test_imposed_employee_create_approved(self):
+        # Create employee
+        self.employee = self.employee_model.create({
+            'name': 'Employee 1',
+        })
+        leaves = self.holiday_model.search(
+            [('type', '=', 'remove'),
+             ('employee_id', '=', self.employee.id)
+             ]
+        )
+        self.assertEqual(len(leaves), 0)
+
+        self.imposed = self.holiday_imposed_model.create(
+            {'name': 'TEST',
+             'date_from': fields.Datetime.to_string(self.today +
+                                                    relativedelta(days=2)),
+             'date_to': fields.Datetime.to_string(self.today +
+                                                  relativedelta(days=4)),
+             'status_id': self.holiday_type.id,
+             'auto_confirm': True
+             }
+            )
+        self.employee2 = self.employee_model.create({
+            'name': 'Employee 2',
+        })
+        leaves = self.holiday_model.search(
+            [('type', '=', 'remove'),
+             ('employee_id', '=', self.employee2.id)
+             ]
+        )
+        self.assertEqual(len(leaves), 1)
+        self.assertEqual(leaves[0].state, 'validate')
+
+    def test_imposed_employee_create_validate(self):
+        # Create employee
+        self.employee = self.employee_model.create({
+            'name': 'Employee 1',
+        })
+        self.employee2 = self.employee_model.create({
+            'name': 'Employee 2',
+        })
+        self.imposed = self.holiday_imposed_model.create(
+            {'name': 'TEST',
+             'date_from': fields.Datetime.to_string(self.today +
+                                                    relativedelta(days=2)),
+             'date_to': fields.Datetime.to_string(self.today +
+                                                  relativedelta(days=4)),
+             'status_id': self.holiday_type.id,
+             'auto_confirm': True
+             }
+            )
+        self.imposed.validate()
+        leaves = self.holiday_model.search(
+            [('type', '=', 'remove'),
+             ('employee_id', 'in', (self.employee.id, self.employee2.id))]
+        )
+        self.assertEqual(len(leaves), 2)
+        self.assertEqual(leaves[0].state, 'validate')

--- a/hr_holidays_imposed_days/tests/test_holidays_imposed_days.py
+++ b/hr_holidays_imposed_days/tests/test_holidays_imposed_days.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests import common
+from odoo.exceptions import ValidationError
 from odoo import fields
 from dateutil.relativedelta import relativedelta
 
@@ -12,6 +13,7 @@ class TestHolidaysImposedDays(common.TransactionCase):
 
     def setUp(self):
         super(TestHolidaysImposedDays, self).setUp()
+        # Base models
         self.employee_model = self.env['hr.employee']
         self.holiday_status_model = self.env['hr.holidays.status']
         self.holiday_imposed_model = self.env['hr.holidays.imposed']
@@ -37,9 +39,34 @@ class TestHolidaysImposedDays(common.TransactionCase):
                                                   relativedelta(days=4)),
              'status_id': self.holiday_type.id,
              }
-            )
+        )
         self.imposed.onchange_dates()
         self.assertEqual(self.imposed.number_of_days, 3.)
+
+    def test_imposed_on_specific_employee(self):
+        # Create employee
+        self.employee = self.employee_model.create({
+            'name': 'Employee 1',
+        })
+        # define an imposed day
+        self.imposed = self.holiday_imposed_model.create(
+            {'name': 'TEST',
+             'date_from': fields.Datetime.to_string(self.today +
+                                                    relativedelta(days=2)),
+             'date_to': fields.Datetime.to_string(self.today +
+                                                  relativedelta(days=4)),
+             'status_id': self.holiday_type.id,
+             'employee_ids': self.employee,
+             }
+        )
+        self.imposed.validate()
+        leaves = self.holiday_model.search(
+            [('type', '=', 'remove'),
+             ('employee_id', '=', self.employee.id)
+             ]
+        )
+        self.assertEqual(len(leaves), 1)
+        self.assertEqual(leaves[0].state, 'confirm')
 
     def test_imposed_employee_create(self):
         # Create employee
@@ -61,7 +88,7 @@ class TestHolidaysImposedDays(common.TransactionCase):
                                                   relativedelta(days=4)),
              'status_id': self.holiday_type.id,
              }
-            )
+        )
         self.employee2 = self.employee_model.create({
             'name': 'Employee 2',
         })
@@ -94,7 +121,7 @@ class TestHolidaysImposedDays(common.TransactionCase):
              'status_id': self.holiday_type.id,
              'auto_confirm': True
              }
-            )
+        )
         self.employee2 = self.employee_model.create({
             'name': 'Employee 2',
         })
@@ -123,7 +150,7 @@ class TestHolidaysImposedDays(common.TransactionCase):
              'status_id': self.holiday_type.id,
              'auto_confirm': True
              }
-            )
+        )
         self.imposed.validate()
         leaves = self.holiday_model.search(
             [('type', '=', 'remove'),
@@ -131,3 +158,18 @@ class TestHolidaysImposedDays(common.TransactionCase):
         )
         self.assertEqual(len(leaves), 2)
         self.assertEqual(leaves[0].state, 'validate')
+
+    def test_check_dates_constrains(self):
+        self.assertRaises(ValidationError, self._create_wrong_imposed)
+
+    def _create_wrong_imposed(self):
+        return self.holiday_imposed_model.create(
+            {'name': 'TEST',
+             'date_from': fields.Datetime.to_string(self.today +
+                                                    relativedelta(days=4)),
+             'date_to': fields.Datetime.to_string(self.today +
+                                                  relativedelta(days=2)),
+             'status_id': self.holiday_type.id,
+             'auto_confirm': True
+             }
+        )

--- a/hr_holidays_imposed_days/tests/test_holidays_imposed_days.py
+++ b/hr_holidays_imposed_days/tests/test_holidays_imposed_days.py
@@ -159,6 +159,21 @@ class TestHolidaysImposedDays(common.TransactionCase):
         self.assertEqual(len(leaves), 2)
         self.assertEqual(leaves[0].state, 'validate')
 
+    def test_same_dates(self):
+        # define an imposed day
+        self.imposed = self.holiday_imposed_model.create(
+            {'name': 'TEST',
+             'date_from': fields.Datetime.to_string(self.today +
+                                                    relativedelta(days=2)),
+             'date_to': fields.Datetime.to_string(self.today +
+                                                  relativedelta(days=2)),
+             'status_id': self.holiday_type.id,
+             }
+        )
+        self.imposed.date_from = self.imposed.date_to
+        self.imposed.onchange_dates()
+        self.assertEqual(self.imposed.number_of_days, 1.)
+
     def test_check_dates_constrains(self):
         self.assertRaises(ValidationError, self._create_wrong_imposed)
 

--- a/hr_holidays_imposed_days/views/imposed_days.xml
+++ b/hr_holidays_imposed_days/views/imposed_days.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<odoo>
+
+    <record id="hr_holidays_imposed_view_tree" model="ir.ui.view">
+        <field name="name">hr.holidays.imposed.view.tree</field>
+        <field name="model">hr.holidays.imposed</field>
+        <field name="arch" type="xml">
+            <tree string="Imposed days">
+                <field name="name"/>
+                <field name="date_from"/>
+                <field name="date_to"/>
+                <field name="number_of_days"/>
+                <field name="company_id"/>
+                <field name="status_id"/>
+                <field name="employee_ids"/>
+                <field name="auto_confirm"/>
+            </tree>
+        </field>
+    </record>
+    <record id="hr_holidays_imposed_view_form" model="ir.ui.view">
+        <field name="name">hr.holidays.imposed.view.form</field>
+        <field name="model">hr.holidays.imposed</field>
+        <field name="arch" type="xml">
+            <form string="Imposed days">
+                <sheet>
+                    <header>
+                        <button type="object" name="validate" string="validate" class="oe_highlight"/>
+                    </header>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="date_from"/>
+                            <field name="date_to"/>
+                            <field name="number_of_days"/>
+                            <field name="auto_confirm"/>
+                        </group>
+                        <group>
+                            <field name="status_id"/>
+                            <field name="company_id"/>
+                        </group>
+                    </group>
+                    <group name="employee_ids" string="Employees">
+                        <field name="employee_ids" nolabel="1"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_hr_holidays_imposed_view" model="ir.actions.act_window">
+        <field name="name">Imposed Days</field>
+        <field name="res_model">hr.holidays.imposed</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <menuitem id="menu_hr_holidays_imposed_view" action="action_hr_holidays_imposed_view" parent="hr_holidays.menu_hr_holidays_root" string="Imposed Days"/>
+
+</odoo>


### PR DESCRIPTION
Migrate #302 from @damdam-s from 9.0 to 10.0

Imposed holidays
================

Allows to manage imposed holidays.

This can be used to manage periods where the company is closed for everyone,
such as end of year celebration. The HR team can use this to easily create
and validate vacations for all the employees of a company. 

**TODO**
- [x] add a constraint on date_start < date_stop