### PR TITLE
[FIX] payslip move date remove unnecessary update

### DIFF
--- a/hr_payslip_move_date/models/hr_payslip.py
+++ b/hr_payslip_move_date/models/hr_payslip.py
@@ -27,8 +27,6 @@ class HrPayslip(models.Model):
             for slip in self:
                 if slip.move_date:
                     self.move_id.write({'date': slip.move_date})
-                    for move_line in slip.move_id.line_id:
-                        move_line.write({'date': slip.move_date})
                 else:
                     self.write({'move_date': slip.move_id.date})
         return res

--- a/hr_payslip_move_date/tests/test_payslip.py
+++ b/hr_payslip_move_date/tests/test_payslip.py
@@ -58,6 +58,10 @@ class PayslipCase(TransactionCase):
         self.assertEqual(
             payslip.move_id.period_id.id,
             self.period_3.id)
+        for line in payslip.move_id.line_id:
+            self.assertEqual(
+                line.date,
+                self.period_3.date_stop)
 
     def test_payslip_run_1(self):
         data = self._prepare_payslip_run_data()


### PR DESCRIPTION

Updating move line is unnecessary and triggers affects_move and todo_date in move line update 

https://github.com/odoo/odoo/blob/8.0/addons/account/account_move_line.py#L1227
https://github.com/odoo/odoo/blob/8.0/addons/account/account_move_line.py#L1233

which results update of move and all other move lines. 

https://github.com/odoo/odoo/blob/8.0/addons/account/account_move_line.py#L1265

This brings a 5 second payslip confirm to 2 minutes (in our case).  This fix cuts it back to 5 seconds.

