### PR TITLE
[10.0] [bugfix] hr_holidays_compute_days: fix computation of number_of_days

### DIFF
--- a/hr_holidays_compute_days/__manifest__.py
+++ b/hr_holidays_compute_days/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Employee Compute Leave Days',
-    'version': '10.0.1.0.0',
+    'version': '10.0.2.0.0',
     'category': 'Human Resources',
     'license': 'AGPL-3',
     'summary': 'Computes the actual leave days '

--- a/hr_holidays_compute_days/models/hr_holidays.py
+++ b/hr_holidays_compute_days/models/hr_holidays.py
@@ -46,7 +46,7 @@ class HrHolidays(models.Model):
                 raise ValidationError(_("You cannot schedule the end date "
                                         "on a public holiday or employee's "
                                         "rest day"))
-            self.number_of_days_temp = self._compute_number_of_days()
+            self.number_of_days_temp = self._recompute_number_of_days()
 
     @api.onchange('date_from')
     def _onchange_date_from(self):
@@ -57,7 +57,7 @@ class HrHolidays(models.Model):
                                     "a public holiday or employee's rest day"))
         if (self.date_to and self.date_from) \
            and (self.date_from <= self.date_to):
-            self.number_of_days_temp = self._compute_number_of_days()
+            self.number_of_days_temp = self._recompute_number_of_days()
 
     @api.onchange('date_to')
     def _onchange_date_to(self):
@@ -68,9 +68,9 @@ class HrHolidays(models.Model):
                                     "a public holiday or employee's rest day"))
         if (self.date_to and self.date_from) \
            and (self.date_from <= self.date_to):
-            self.number_of_days_temp = self._compute_number_of_days()
+            self.number_of_days_temp = self._recompute_number_of_days()
 
-    def _compute_number_of_days(self):
+    def _recompute_number_of_days(self):
         date_from = self.date_from
         date_to = self.date_to
         employee_id = self.employee_id.id
@@ -98,5 +98,4 @@ class HrHolidays(models.Model):
                 ):
                     days -= 1
                 date_dt += relativedelta(days=1)
-        self.number_of_days = days
         return days

--- a/hr_holidays_compute_days/tests/test_holidays_compute_days.py
+++ b/hr_holidays_compute_days/tests/test_holidays_compute_days.py
@@ -166,6 +166,18 @@ class TestHolidaysComputeDays(common.TransactionCase):
                 })
             leave._onchange_employee(self.employee2.id)
 
+    def test_leave_allocation_ok(self):
+        """allocate 10 days of holidays"""
+        leave = self.holiday_model.new({
+            'name': 'Hol14',
+            'employee_id': self.employee.id,
+            'type': 'add',
+            'number_of_days_temp': 10,
+            'holiday_type': 'employee',
+            'holiday_status_id': self.holiday_type.id,
+        })
+        self.assertEquals(leave.number_of_days, 10)
+
     def test_leave_creation_ok(self):
         # let's schedule holiday with date_from and date to in working days
         leave = self.holiday_model.new({
@@ -193,6 +205,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
         })
         leave._onchange_date_from()
         self.assertEqual(leave.number_of_days_temp, 5)
+        self.assertEqual(leave.number_of_days, -5)
 
     def test_overlap_weekend(self):
         # let's leave schedule overlap weekend
@@ -207,6 +220,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
         })
         leave._onchange_date_from()
         self.assertEqual(leave.number_of_days_temp, 5)
+        self.assertEqual(leave.number_of_days, -5)
 
     def test_overlap_holiday_and_rest_day(self):
         # let's leave schedule overlap weekend and public holiday
@@ -221,6 +235,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
         })
         leave._onchange_date_from()
         self.assertEqual(leave.number_of_days_temp, 5)
+        self.assertEqual(leave.number_of_days, -5)
 
     def test_overlap_for_non_conventional_rest_day(self):
         # let's leave schedule overlap on restday for non conventional restday
@@ -255,6 +270,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
         })
         leave._onchange_date_from()
         self.assertEqual(leave.number_of_days_temp, 5)
+        self.assertEqual(leave.number_of_days, -5)
 
     def test_no_exclude_holiday_and_rest_day(self):
         # we have a holiday type that does not exclude public holiday or
@@ -276,6 +292,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
         })
         leave._onchange_date_from()
         self.assertEqual(leave.number_of_days_temp, 5)
+        self.assertEqual(leave.number_of_days, -5)
 
     def test_no_exclude_holiday(self):
         # lwe have a holiday type that excludes on rest days
@@ -296,6 +313,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
         })
         leave._onchange_date_from()
         self.assertEqual(leave.number_of_days_temp, 5)
+        self.assertEqual(leave.number_of_days, -5)
 
     def test_no_exclude_rest_day(self):
         # lwe have a holiday type that does not exclude rest days
@@ -316,6 +334,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
         })
         leave._onchange_date_from()
         self.assertEqual(leave.number_of_days_temp, 5)
+        self.assertEqual(leave.number_of_days, -5)
 
     def test_no_schedule_holiday_and_rest_day(self):
         # let's run test assumign employee has not schedule
@@ -335,6 +354,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
         })
         leave._onchange_date_from()
         self.assertEqual(leave.number_of_days_temp, 5)
+        self.assertEqual(leave.number_of_days, -5)
 
     def test_no_contract_holiday_and_rest_day(self):
         # let's run test assumign employee has not schedule
@@ -350,6 +370,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
         })
         leave._onchange_date_from()
         self.assertEqual(leave.number_of_days_temp, 5)
+        self.assertEqual(leave.number_of_days, -5)
 
     def test_onchange_employee(self):
         # let's run test assumign employee has not schedule


### PR DESCRIPTION
# issue 1

*    install hr_holidays_compute_days
*    create a 3 day holiday allocation for any employee
*    go to leave summary and check the allocation

*expected:* the duration is 3 days
*actual:* the duration is 0 days

# issue 2:

*    install hr_holidays_compute_days
*   create a 3 day holiday request in the middle of the week for any employee
*    go to leave summary and check the request

*expected duration:* -3 days
*actual duration:* +3 days.

#Analysis 

There is a name collision between `_compute_number_of_days` defined in this addon
and the method for the `field number_of_days` computation in the base addon `hr_holidays`
which causes the latter to not be called => the field `number_of_days` would be 0 for
holidays allocation, and has the wrong sign for holidays request (because it was
wrongly forced in the the reimplemented version.

This patch:
* adds tests for the expected value of number_of_days
* adds a test for the behavior of the method for holidays allocation
* renames the method _compute_number_of_days to _recompute_number_of_days
