### PR TITLE
[FIX][10.0] hr_holidays_leave_auto_approve avoid approval message

### DIFF
--- a/hr_holidays_leave_auto_approve/__init__.py
+++ b/hr_holidays_leave_auto_approve/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# Copyright 2016 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/hr_holidays_leave_auto_approve/__manifest__.py
+++ b/hr_holidays_leave_auto_approve/__manifest__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# Copyright 2016 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
@@ -7,7 +7,7 @@
     'version': '10.0.1.0.0',
     'license': 'AGPL-3',
     'summary': '''Leave type for auto approval of Leaves''',
-    'author': 'ONESTEiN BV, Odoo Community Association (OCA)',
+    'author': 'Onestein, Odoo Community Association (OCA)',
     'website': 'http://www.onestein.eu',
     'category': 'Human Resources',
     'depends': [

--- a/hr_holidays_leave_auto_approve/models/__init__.py
+++ b/hr_holidays_leave_auto_approve/models/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# Copyright 2016 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import hr_holidays

--- a/hr_holidays_leave_auto_approve/models/hr_holidays.py
+++ b/hr_holidays_leave_auto_approve/models/hr_holidays.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# Copyright 2016 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models, api
@@ -16,9 +16,21 @@ class HrHolidays(models.Model):
 
     @api.model
     def create(self, values):
-        res = super(HrHolidays, self).create(values)
-        if self.env.user.sudo().has_group(
+        auto_approve = self._get_auto_approve_on_creation(values)
+        res = super(HrHolidays, self.with_context(
+            tracking_disable=auto_approve)
+        ).create(values)
+        if self.sudo().env.user.has_group(
                 'hr_holidays.group_hr_holidays_user'):
             if res.holiday_status_id and res.holiday_status_id.auto_approve:
                 res.sudo().action_approve()
         return res
+
+    @api.model
+    def _get_auto_approve_on_creation(self, values):
+        auto_approve = False
+        if values.get('holiday_status_id'):
+            auto_approve = self.env['hr.holidays.status'].browse(
+                values.get('holiday_status_id')
+            ).auto_approve
+        return auto_approve

--- a/hr_holidays_leave_auto_approve/models/hr_holidays_status.py
+++ b/hr_holidays_leave_auto_approve/models/hr_holidays_status.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# Copyright 2016 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models, fields

--- a/hr_holidays_leave_auto_approve/tests/__init__.py
+++ b/hr_holidays_leave_auto_approve/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# Copyright 2016 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_hr_holidays_leave_auto_approve

--- a/hr_holidays_leave_auto_approve/tests/test_hr_holidays_leave_auto_approve.py
+++ b/hr_holidays_leave_auto_approve/tests/test_hr_holidays_leave_auto_approve.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# Copyright 2016 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from datetime import datetime, timedelta


### PR DESCRIPTION
This PR contains a fix and a code review for module `hr_holidays_leave_auto_approve`.

Current behavior:

- creating a leave request with an auto-approve leave type, a message is sent to the managers asking for their approval.

With this PR:

- when a leave request has an auto-approve leave type, it doesn't send a message to ask for approval by the managers;
- a separate method is added to get the value of auto_approve; this way the method will be ready to be extended in case of further customizations need.

At the same time, this PR includes a general code review according with OCA guidelines.
