### PR TITLE
[FIX][10.0] broken 10.0 build

### DIFF
--- a/hr_holidays_leave_auto_approve/tests/test_hr_holidays_leave_auto_approve.py
+++ b/hr_holidays_leave_auto_approve/tests/test_hr_holidays_leave_auto_approve.py
@@ -73,7 +73,7 @@ class TestHolidaysAutoApprove(TransactionCase):
             'name': 'Test Leave Request 1',
             'holiday_status_id': self.test_leave_type1_id.id,
             'date_from': today.strftime(DF),
-            'date_to': (today + timedelta(days=2)).strftime(DF),
+            'date_to': (today + timedelta(days=1)).strftime(DF),
             'holiday_type': 'employee',
             'employee_id': self.test_employee_id.id,
             'type': 'remove',
@@ -82,7 +82,7 @@ class TestHolidaysAutoApprove(TransactionCase):
         leave2 = self.leave_request_model.create({
             'name': 'Test Leave Request 2',
             'holiday_status_id': self.test_leave_type2_id.id,
-            'date_from': (today + timedelta(days=4)).strftime(DF),
+            'date_from': (today + timedelta(days=5)).strftime(DF),
             'date_to': (today + timedelta(days=8)).strftime(DF),
             'holiday_type': 'employee',
             'employee_id': self.test_employee_id.id,


### PR DESCRIPTION
Attempt to fix the broken 10.0 build, due to tests of `hr_holidays_leave_auto_approve` that seem conflicting with tests of module `hr_holidays_imposed_days`.
