### PR TITLE
[FIX][10.0] Tests of hr_holidays_compute_days

### DIFF
--- a/hr_holidays_compute_days/tests/test_holidays_compute_days.py
+++ b/hr_holidays_compute_days/tests/test_holidays_compute_days.py
@@ -164,7 +164,7 @@ class TestHolidaysComputeDays(common.TransactionCase):
                     'date_from': '1994-10-25 08:00:00',
                     'date_to': '1994-10-28 18:00:00',
                 })
-            leave._onchange_employee(self.employee2.id)
+            leave._onchange_employee()
 
     def test_leave_allocation_ok(self):
         """allocate 10 days of holidays"""


### PR DESCRIPTION
Actually the tests of hr_holidays_compute_days seem not passing on branch 10.0.

See [travis](https://travis-ci.org/OCA/hr/jobs/253547301), just got the following error while opening PR https://github.com/OCA/hr/pull/350:

```
ERROR: test_schedule_on_public_holiday (odoo.addons.hr_holidays_compute_days.tests.test_holidays_compute_days.TestHolidaysComputeDays)
Traceback (most recent call last):
`   File "/home/travis/build/OCA/hr/hr_holidays_compute_days/tests/test_holidays_compute_days.py", line 167, in test_schedule_on_public_holiday
`     leave._onchange_employee(self.employee2.id)
` TypeError: _onchange_employee() takes exactly 1 argument (2 given)
FAILED
Module hr_holidays_compute_days: 0 failures, 1 errors
```