### PR TITLE
[fix] `hr_employee_id` use deprecated `sequence.get_id()`

### DIFF
--- a/hr_employee_id/__manifest__.py
+++ b/hr_employee_id/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Employee ID',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'license': 'AGPL-3',
     'category': 'Generic Modules/Human Resources',
     'author': 'Michael Telahun Makonnen, '

--- a/hr_employee_id/models/hr_employee.py
+++ b/hr_employee_id/models/hr_employee.py
@@ -30,8 +30,7 @@ class HrEmployee(models.Model):
         company = self.env.user.company_id
         employee_id = False
         if company.employee_id_gen_method == 'sequence':
-            employee_id = self.env['ir.sequence'].get_id(
-                company.employee_id_sequence.id)
+            employee_id = company.employee_id_sequence.next_by_id()
         elif company.employee_id_gen_method == 'random':
             employee_id_random_digits = company.employee_id_random_digits
             tries = 0


### PR DESCRIPTION
Fix deprecation warning:

```bash
WARNING odoodb odoo.addons.base.ir.ir_sequence: ir_sequence.get() and ir_sequence.get_id() are deprecated. Please use ir_sequence.next_by_code() or ir_sequence.next_by_id()
```