### PR TITLE
[9.0] hr_public_holidays allow duplicate of year

### DIFF
--- a/hr_public_holidays/models/hr_public_holidays.py
+++ b/hr_public_holidays/models/hr_public_holidays.py
@@ -4,6 +4,7 @@
 
 from datetime import date
 from openerp import fields, models, api
+from openerp.tools.translate import _
 from openerp.exceptions import Warning as UserError
 from dateutil.relativedelta import relativedelta
 
@@ -36,9 +37,10 @@ class HrPublicHolidays(models.Model):
         'Country'
     )
 
-    @api.one
+    @api.multi
     @api.constrains('year', 'country_id')
     def _check_year(self):
+        self.ensure_one()
         if self.country_id:
             domain = [('year', '=', self.year),
                       ('country_id', '=', self.country_id.id),
@@ -48,13 +50,14 @@ class HrPublicHolidays(models.Model):
                       ('country_id', '=', False),
                       ('id', '!=', self.id)]
         if self.search_count(domain):
-            raise UserError('You can\'t create duplicate public holiday '
-                            'per year and/or country')
+            raise UserError(_('You can\'t create duplicate public holiday '
+                            'per year and/or country'))
         return True
 
-    @api.one
+    @api.multi
     @api.depends('year', 'country_id')
     def _compute_display_name(self):
+        self.ensure_one()
         if self.country_id:
             self.display_name = '%s (%s)' % (self.year, self.country_id.name)
         else:
@@ -121,9 +124,9 @@ class HrPublicHolidays(models.Model):
             return True
         return False
     
-    def copy_data(self, cr, uid, id, default=None, context=None):
+    def copy_data(self, *args, **kwargs):
         data = super(HrPublicHolidays, self).copy_data(
-            cr, uid, id, default=default, context=context)
+            *args, **kwargs)
         data['year'] += 1
         for line in data['line_ids']:
             val = line[2]

--- a/hr_public_holidays/models/hr_public_holidays.py
+++ b/hr_public_holidays/models/hr_public_holidays.py
@@ -123,13 +123,14 @@ class HrPublicHolidays(models.Model):
                 lambda r: r.date == fields.Date.to_string(selected_date))):
             return True
         return False
-    
+
     def copy_data(self, *args, **kwargs):
         data = super(HrPublicHolidays, self).copy_data(
             *args, **kwargs)
         data['year'] += 1
         for line in data['line_ids']:
             val = line[2]
-            new_date = fields.Date.from_string(val['date'])+relativedelta(years=1)
+            base_date = fields.Date.from_string(val['date'])
+            new_date = base_date+relativedelta(years=1)
             val['date'] = fields.Date.to_string(new_date)
         return data

--- a/hr_public_holidays/models/hr_public_holidays.py
+++ b/hr_public_holidays/models/hr_public_holidays.py
@@ -121,17 +121,12 @@ class HrPublicHolidays(models.Model):
             return True
         return False
     
-    @api.returns('self', lambda value: value.id)
-    def copy(self, cr, uid, id, default=None, context=None):
-        if context is None:
-            context = {}
-        context = context.copy()
-        data = self.copy_data(cr, uid, id, default, context)
+    def copy_data(self, cr, uid, id, default=None, context=None):
+        data = super(HrPublicHolidays, self).copy_data(
+            cr, uid, id, default=default, context=context)
         data['year'] += 1
         for line in data['line_ids']:
             val = line[2]
             new_date = fields.Date.from_string(val['date'])+relativedelta(years=1)
             val['date'] = fields.Date.to_string(new_date)
-        new_id = self.create(cr, uid, data, context)
-        self.copy_translations(cr, uid, id, new_id, context)
-        return new_id
+        return data

--- a/hr_public_holidays/models/hr_public_holidays.py
+++ b/hr_public_holidays/models/hr_public_holidays.py
@@ -5,6 +5,7 @@
 from datetime import date
 from openerp import fields, models, api
 from openerp.exceptions import Warning as UserError
+from dateutil.relativedelta import relativedelta
 
 
 class HrPublicHolidays(models.Model):

--- a/hr_public_holidays/models/hr_public_holidays.py
+++ b/hr_public_holidays/models/hr_public_holidays.py
@@ -51,7 +51,7 @@ class HrPublicHolidays(models.Model):
                       ('id', '!=', self.id)]
         if self.search_count(domain):
             raise UserError(_('You can\'t create duplicate public holiday '
-                            'per year and/or country'))
+                              'per year and/or country'))
         return True
 
     @api.multi

--- a/hr_public_holidays/models/hr_public_holidays.py
+++ b/hr_public_holidays/models/hr_public_holidays.py
@@ -28,6 +28,7 @@ class HrPublicHolidays(models.Model):
         'hr.holidays.public.line',
         'year_id',
         'Holiday Dates'
+        copy=True
     )
     country_id = fields.Many2one(
         'res.country',
@@ -118,3 +119,18 @@ class HrPublicHolidays(models.Model):
                 lambda r: r.date == fields.Date.to_string(selected_date))):
             return True
         return False
+    
+    @api.returns('self', lambda value: value.id)
+    def copy(self, cr, uid, id, default=None, context=None):
+        if context is None:
+            context = {}
+        context = context.copy()
+        data = self.copy_data(cr, uid, id, default, context)
+        data['year'] += 1
+        for line in data['line_ids']:
+            val = line[2]
+            new_date = fields.Date.from_string(val['date'])+relativedelta(years=1)
+            val['date'] = fields.Date.to_string(new_date)
+        new_id = self.create(cr, uid, data, context)
+        self.copy_translations(cr, uid, id, new_id, context)
+        return new_id

--- a/hr_public_holidays/models/hr_public_holidays.py
+++ b/hr_public_holidays/models/hr_public_holidays.py
@@ -28,7 +28,7 @@ class HrPublicHolidays(models.Model):
     line_ids = fields.One2many(
         'hr.holidays.public.line',
         'year_id',
-        'Holiday Dates'
+        'Holiday Dates',
         copy=True
     )
     country_id = fields.Many2one(

--- a/hr_public_holidays/models/hr_public_holidays_line.py
+++ b/hr_public_holidays/models/hr_public_holidays_line.py
@@ -24,6 +24,7 @@ class HrPublicHolidaysLine(models.Model):
         'hr.holidays.public',
         'Calendar Year',
         required=True,
+        ondelete="cascade"
     )
     variable = fields.Boolean('Date may change')
     state_ids = fields.Many2many(

--- a/hr_public_holidays/models/hr_public_holidays_line.py
+++ b/hr_public_holidays/models/hr_public_holidays_line.py
@@ -43,7 +43,7 @@ class HrPublicHolidaysLine(models.Model):
         if fields.Date.from_string(self.date).year != self.year_id.year:
             raise UserError(
                 _('Dates of holidays should be the same year '
-                    'as the calendar year they are being assigned to')
+                  'as the calendar year they are being assigned to')
             )
         if self.state_ids:
             domain = [('date', '=', self.date),
@@ -54,12 +54,12 @@ class HrPublicHolidaysLine(models.Model):
             for holiday in holidays:
                 if self.state_ids & holiday.state_ids:
                     raise UserError(_('You can\'t create duplicate public '
-                        'holiday per date %s and one of the '
-                        'country states.') % self.date)
+                                      'holiday per date %s and one of the '
+                                      'country states.') % self.date)
         domain = [('date', '=', self.date),
                   ('year_id', '=', self.year_id.id),
                   ('state_ids', '=', False)]
         if self.search_count(domain) > 1:
             raise UserError(_('You can\'t create duplicate public holiday '
-                            'per date %s.') % self.date)
+                              'per date %s.') % self.date)
         return True

--- a/hr_public_holidays/models/hr_public_holidays_line.py
+++ b/hr_public_holidays/models/hr_public_holidays_line.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import fields, models, api
+from openerp.tools.translate import _
 from openerp.exceptions import Warning as UserError
 
 
@@ -35,13 +36,14 @@ class HrPublicHolidaysLine(models.Model):
         'Related States'
     )
 
-    @api.one
+    @api.multi
     @api.constrains('date', 'state_ids')
     def _check_date_state(self):
+        self.ensure_one()
         if fields.Date.from_string(self.date).year != self.year_id.year:
             raise UserError(
-                'Dates of holidays should be the same year '
-                'as the calendar year they are being assigned to'
+                _('Dates of holidays should be the same year '
+                'as the calendar year they are being assigned to')
             )
         if self.state_ids:
             domain = [('date', '=', self.date),
@@ -51,13 +53,13 @@ class HrPublicHolidaysLine(models.Model):
             holidays = self.search(domain)
             for holiday in holidays:
                 if self.state_ids & holiday.state_ids:
-                    raise UserError('You can\'t create duplicate public '
+                    raise UserError(_('You can\'t create duplicate public '
                                     'holiday per date %s and one of the '
-                                    'country states.' % self.date)
+                                    'country states.') % self.date)
         domain = [('date', '=', self.date),
                   ('year_id', '=', self.year_id.id),
                   ('state_ids', '=', False)]
         if self.search_count(domain) > 1:
-            raise UserError('You can\'t create duplicate public holiday '
-                            'per date %s.' % self.date)
+            raise UserError(_('You can\'t create duplicate public holiday '
+                            'per date %s.') % self.date)
         return True

--- a/hr_public_holidays/models/hr_public_holidays_line.py
+++ b/hr_public_holidays/models/hr_public_holidays_line.py
@@ -43,7 +43,7 @@ class HrPublicHolidaysLine(models.Model):
         if fields.Date.from_string(self.date).year != self.year_id.year:
             raise UserError(
                 _('Dates of holidays should be the same year '
-                'as the calendar year they are being assigned to')
+                    'as the calendar year they are being assigned to')
             )
         if self.state_ids:
             domain = [('date', '=', self.date),
@@ -54,8 +54,8 @@ class HrPublicHolidaysLine(models.Model):
             for holiday in holidays:
                 if self.state_ids & holiday.state_ids:
                     raise UserError(_('You can\'t create duplicate public '
-                                    'holiday per date %s and one of the '
-                                    'country states.') % self.date)
+                        'holiday per date %s and one of the '
+                        'country states.') % self.date)
         domain = [('date', '=', self.date),
                   ('year_id', '=', self.year_id.id),
                   ('state_ids', '=', False)]


### PR DESCRIPTION
As it is now, this is not possible to duplicate a year that makes it boring to creates new years.
That PR allows to easily create new years by making the copy of the year and related lines plus one year.
It allows also to deletion the created year if needed.

This will have to be forwarded to 10.0 and 11.0