### PR TITLE
[imp] hr_employee_id: ease override w/ custom ID

### DIFF
--- a/hr_employee_id/README.rst
+++ b/hr_employee_id/README.rst
@@ -14,6 +14,10 @@ Company wide unique employee ID. Supports:
 This module supports sequence of employee ID which will be generated
 automatically from the sequence predefined.
 
+Nevertheless, if you need a difference ID in particular cases
+you can pass a custom value for `identification_id`: if you do it
+no automatic generation happens.
+
 Installation
 ============
 
@@ -70,6 +74,7 @@ Contributors
 * Adrien Peiffer (ACSONE) <adrien.peiffer@acsone.eu>
 * Salton Massally (iDT Labs) <smassally@idtlabs.sl>
 * Andhitia Rama (OpenSynergy Indonesia) <andhitia.r@gmail.com>
+* Simone Orsi <simone.orsi@camptocamp.com>
 
 Maintainer
 ----------

--- a/hr_employee_id/__manifest__.py
+++ b/hr_employee_id/__manifest__.py
@@ -4,11 +4,12 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Employee ID',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
     'category': 'Generic Modules/Human Resources',
     'author': 'Michael Telahun Makonnen, '
               'OpenSynergy Indonesia,'
+              'Camptocamp,'
               'Odoo Community Association (OCA)',
     'website': 'http://miketelahun.wordpress.com',
     'depends': [

--- a/hr_employee_id/models/hr_employee.py
+++ b/hr_employee_id/models/hr_employee.py
@@ -52,6 +52,6 @@ class HrEmployee(models.Model):
 
     @api.model
     def create(self, vals):
-        eid = self._generate_identification_id()
-        vals['identification_id'] = eid
+        if not vals.get('identification_id'):
+            vals['identification_id'] = self._generate_identification_id()
         return super(HrEmployee, self).create(vals)

--- a/hr_employee_id/tests/test_employee_id.py
+++ b/hr_employee_id/tests/test_employee_id.py
@@ -35,6 +35,18 @@ class TestEmployeeID(common.TransactionCase):
 
         self.assertTrue(len(employee.identification_id))
 
+    def test_custom_id(self):
+        # if we pass the ID no generation occurs.
+        # Let's set a sequence and check that is not used at all
+        self.company.write({'employee_id_gen_method': 'sequence',
+                            'employee_id_sequence': self.sequence.id})
+        number = self.sequence.number_next
+        employee = self.employee_model.create({
+            'name': 'Employee', 'identification_id': 'THERE_YOU_GO'
+        })
+        self.assertEqual(employee.identification_id, 'THERE_YOU_GO')
+        self.assertEqual(self.sequence.number_next, number)
+
     def test_configuration_default_values(self):
         # test loading of default configuration values
         self.company.write({'employee_id_gen_method': None,


### PR DESCRIPTION
If you need a difference ID in particular cases you can pass a custom value for identification_id: if you do it no automatic generation happens.