### PR TITLE
[FIX] hr_employee_seniority permission problem

### DIFF
--- a/hr_employee_seniority/__manifest__.py
+++ b/hr_employee_seniority/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Employee Seniority',
     'summary': 'Keep Track of Length of Employment',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Human Resources',
     'author': "Michael Telahun Makonnen <mmakonnen@gmail.com>, "
               "Camptocamp SA, "

--- a/hr_employee_seniority/models/hr_employee.py
+++ b/hr_employee_seniority/models/hr_employee.py
@@ -20,7 +20,7 @@ class HrEmployee(models.Model):
     )
     length_of_service = fields.Float(
         'Months of Service',
-        compute='_compute_months_service',
+        compute_sudo='_compute_months_service',
     )
 
     def _first_contract(self):


### PR DESCRIPTION
normally hr.contract are only readable by Employee / Officer and Employee / Managers,
not basic employees => we need compute_sudo to compute the employee's seniority otherwise
the employee cannot display his own record.