### PR TITLE
[10.0] [FIX] Fix error when journal don't have update_posted checked.

### DIFF
--- a/hr_payroll_cancel/models/hr_payroll.py
+++ b/hr_payroll_cancel/models/hr_payroll.py
@@ -31,6 +31,10 @@ class HrPayslip(models.Model):
             if payslip.refunded_id and payslip.refunded_id.state != 'cancel':
                 raise ValidationError(_("""To cancel the Original Payslip the
                     Refunded Payslip needed to be canceled first!"""))
-            payslip.move_id.button_cancel()
-            payslip.move_id.unlink()
+            if payslip.move_id.journal_id.update_posted:
+                payslip.move_id.button_cancel()
+                payslip.move_id.unlink()
+            else:
+                payslip.move_id.reverse_move()
+                payslip.move_id = False
             return payslip.write({'state': 'cancel'})


### PR DESCRIPTION
When the payslip journal is not set as update_posted it will raise an error, so instead we are reversing the move of the payslip and set move_id field to False.