### PR TITLE
[11.0][ADD] Module hr_holidays_leave_overlap

### DIFF
--- a/hr_holidays_leave_overlap/README.rst
+++ b/hr_holidays_leave_overlap/README.rst
@@ -1,0 +1,64 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===========================
+HR - Holiday Leaves Overlap
+===========================
+
+This modules allows holiday leaves overlap, automatically handling them, adapting or
+splitting the new leave request in order to arrange it in a time period where other
+leaves were already registered.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. No configuration needed. Just install the module.
+
+Usage
+=====
+
+To use this module, you just need to create a new leave request on a time period
+overlapping an already existing leave. The system will take care of everything.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/116/11.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/hr/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Antonio Esposito <a.esposito@onestein.nl>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/hr_holidays_leave_overlap/README.rst
+++ b/hr_holidays_leave_overlap/README.rst
@@ -10,13 +10,6 @@ This modules allows holiday leaves overlap, automatically handling them, adaptin
 splitting the new leave request in order to arrange it in a time period where other
 leaves were already registered.
 
-Configuration
-=============
-
-To configure this module, you need to:
-
-#. No configuration needed. Just install the module.
-
 Usage
 =====
 

--- a/hr_holidays_leave_overlap/__init__.py
+++ b/hr_holidays_leave_overlap/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/hr_holidays_leave_overlap/__init__.py
+++ b/hr_holidays_leave_overlap/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models

--- a/hr_holidays_leave_overlap/__manifest__.py
+++ b/hr_holidays_leave_overlap/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    'name': "HR - Holiday Leaves Overlap",
+    'summary': """Handle leaves overlap""",
+    'author': 'Onestein, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'website': 'http://www.onestein.eu',
+    'category': 'Human Resources',
+    'version': '11.0.1.0.0',
+    'depends': [
+        'hr_holidays',
+    ],
+    'data': [],
+    'installable': True,
+}

--- a/hr_holidays_leave_overlap/__manifest__.py
+++ b/hr_holidays_leave_overlap/__manifest__.py
@@ -6,7 +6,7 @@
     'summary': 'Handle leaves overlap',
     'author': 'Onestein, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
-    'website': 'http://www.onestein.eu',
+    'website': 'https://github.com/OCA/hr/tree/11.0',
     'category': 'Human Resources',
     'version': '11.0.1.0.0',
     'depends': [

--- a/hr_holidays_leave_overlap/__manifest__.py
+++ b/hr_holidays_leave_overlap/__manifest__.py
@@ -2,8 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
-    'name': "HR - Holiday Leaves Overlap",
-    'summary': """Handle leaves overlap""",
+    'name': 'HR - Holiday Leaves Overlap',
+    'summary': 'Handle leaves overlap',
     'author': 'Onestein, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'website': 'http://www.onestein.eu',
@@ -12,6 +12,5 @@
     'depends': [
         'hr_holidays',
     ],
-    'data': [],
     'installable': True,
 }

--- a/hr_holidays_leave_overlap/models/__init__.py
+++ b/hr_holidays_leave_overlap/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import hr_holidays

--- a/hr_holidays_leave_overlap/models/__init__.py
+++ b/hr_holidays_leave_overlap/models/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import hr_holidays

--- a/hr_holidays_leave_overlap/models/hr_holidays.py
+++ b/hr_holidays_leave_overlap/models/hr_holidays.py
@@ -1,0 +1,104 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from datetime import timedelta
+
+
+class HrHolidays(models.Model):
+    _inherit = 'hr.holidays'
+
+    @api.model
+    def create(self, values):
+        if values['type'] == 'remove':
+
+            including = self.search([
+                ('date_from', '<', values['date_from']),
+                ('date_to', '>', values['date_to']),
+                ('employee_id', '=', values['employee_id']),
+                ('type', '=', values['type']),
+                ('state', 'not in', ['cancel', 'refuse']),
+            ], limit=1)
+            if including:
+                raise ValidationError(_(
+                    'You are trying to create a leave on a period which is '
+                    'already completely covered by a different leave!')
+                )
+
+            base_date = [values['date_from'], values['date_to']]
+            split_date = []
+            stepping_date = []
+
+            left_overlapping = self.search([
+                ('date_from', '<', values['date_from']),
+                ('date_to', '>', values['date_from']),
+                ('date_to', '<=', values['date_to']),
+                ('employee_id', '=', values['employee_id']),
+                ('type', '=', values['type']),
+                ('state', 'not in', ['cancel', 'refuse']),
+            ], limit=1)
+
+            for leave in left_overlapping:
+                base_date[0] = fields.Datetime.to_string(
+                    fields.Datetime.from_string(leave.date_to) +
+                    timedelta(seconds=1)
+                )
+
+            included = self.search([
+                ('date_from', '>=', values['date_from']),
+                ('date_to', '<=', values['date_to']),
+                ('employee_id', '=', values['employee_id']),
+                ('type', '=', values['type']),
+                ('state', 'not in', ['cancel', 'refuse']),
+            ], order='date_from ASC')
+
+            for leave in included:
+                if not stepping_date and base_date[0] == leave.date_from:
+                    base_date[0] = fields.Datetime.to_string(
+                        fields.Datetime.from_string(leave.date_to) +
+                        timedelta(seconds=1))
+                    continue
+
+                s_date = stepping_date and stepping_date[-1] or base_date[0]
+                e_date = fields.Datetime.to_string(
+                    fields.Datetime.from_string(leave.date_from) -
+                    timedelta(seconds=1)
+                )
+                split_date.append((s_date, e_date))
+                stepping_date.append(fields.Datetime.to_string(
+                    fields.Datetime.from_string(leave.date_to) +
+                    timedelta(seconds=1))
+                )
+
+            right_overlapping = self.search([
+                ('date_from', '>=', values['date_from']),
+                ('date_from', '<', values['date_to']),
+                ('date_to', '>', values['date_to']),
+                ('employee_id', '=', values['employee_id']),
+                ('type', '=', values['type']),
+                ('state', 'not in', ['cancel', 'refuse']),
+            ], limit=1)
+
+            if right_overlapping:
+                base_date[1] = fields.Datetime.to_string(
+                    fields.Datetime.from_string(right_overlapping.date_from) -
+                    timedelta(seconds=1)
+                )
+                if stepping_date:
+                    split_date.append(stepping_date[-1], base_date[1])
+            elif stepping_date and split_date:
+                split_date.append((stepping_date[-1], base_date[1]))
+
+            if not split_date:
+                split_date.append(base_date)
+
+            for period in split_date:
+                new_vals = values.copy()
+                new_vals['date_from'] = period[0]
+                new_vals['date_to'] = period[1]
+
+                res = super(HrHolidays, self).create(new_vals)
+            return res
+        else:
+            return super(HrHolidays, self).create(values)

--- a/hr_holidays_leave_overlap/models/hr_holidays.py
+++ b/hr_holidays_leave_overlap/models/hr_holidays.py
@@ -1,9 +1,9 @@
 # Copyright 2018 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import timedelta
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from datetime import timedelta
 
 
 class HrHolidays(models.Model):
@@ -60,12 +60,13 @@ class HrHolidays(models.Model):
                         timedelta(seconds=1))
                     continue
 
-                s_date = stepping_date and stepping_date[-1] or base_date[0]
-                e_date = fields.Datetime.to_string(
+                start_date = stepping_date and stepping_date[-1] or \
+                             base_date[0]
+                end_date = fields.Datetime.to_string(
                     fields.Datetime.from_string(leave.date_from) -
                     timedelta(seconds=1)
                 )
-                split_date.append((s_date, e_date))
+                split_date.append((start_date, end_date))
                 stepping_date.append(fields.Datetime.to_string(
                     fields.Datetime.from_string(leave.date_to) +
                     timedelta(seconds=1))
@@ -100,5 +101,4 @@ class HrHolidays(models.Model):
 
                 res = super(HrHolidays, self).create(new_vals)
             return res
-        else:
-            return super(HrHolidays, self).create(values)
+        return super(HrHolidays, self).create(values)

--- a/hr_holidays_leave_overlap/models/hr_holidays.py
+++ b/hr_holidays_leave_overlap/models/hr_holidays.py
@@ -11,7 +11,7 @@ class HrHolidays(models.Model):
 
     @api.model
     def create(self, values):
-        if values['type'] == 'remove':
+        if values.get('type', False) == 'remove':
 
             including = self.search([
                 ('date_from', '<', values['date_from']),
@@ -60,8 +60,10 @@ class HrHolidays(models.Model):
                         timedelta(seconds=1))
                     continue
 
-                start_date = stepping_date and stepping_date[-1] or \
-                             base_date[0]
+                start_date = (
+                    stepping_date and stepping_date[-1] or
+                    base_date[0]
+                )
                 end_date = fields.Datetime.to_string(
                     fields.Datetime.from_string(leave.date_from) -
                     timedelta(seconds=1)

--- a/hr_holidays_leave_overlap/models/hr_holidays.py
+++ b/hr_holidays_leave_overlap/models/hr_holidays.py
@@ -13,10 +13,14 @@ class HrHolidays(models.Model):
     def create(self, values):
         if values.get('type', False) == 'remove':
 
+            values['employee_id'] = values.get('employee_id', False)
+            values['category_id'] = values.get('category_id', False)
+
             including = self.search([
                 ('date_from', '<', values['date_from']),
                 ('date_to', '>', values['date_to']),
                 ('employee_id', '=', values['employee_id']),
+                ('category_id', '=', values['category_id']),
                 ('type', '=', values['type']),
                 ('state', 'not in', ['cancel', 'refuse']),
             ], limit=1)
@@ -35,6 +39,7 @@ class HrHolidays(models.Model):
                 ('date_to', '>', values['date_from']),
                 ('date_to', '<=', values['date_to']),
                 ('employee_id', '=', values['employee_id']),
+                ('category_id', '=', values['category_id']),
                 ('type', '=', values['type']),
                 ('state', 'not in', ['cancel', 'refuse']),
             ], limit=1)
@@ -49,6 +54,7 @@ class HrHolidays(models.Model):
                 ('date_from', '>=', values['date_from']),
                 ('date_to', '<=', values['date_to']),
                 ('employee_id', '=', values['employee_id']),
+                ('category_id', '=', values['category_id']),
                 ('type', '=', values['type']),
                 ('state', 'not in', ['cancel', 'refuse']),
             ], order='date_from ASC')
@@ -79,6 +85,7 @@ class HrHolidays(models.Model):
                 ('date_from', '<', values['date_to']),
                 ('date_to', '>', values['date_to']),
                 ('employee_id', '=', values['employee_id']),
+                ('category_id', '=', values['category_id']),
                 ('type', '=', values['type']),
                 ('state', 'not in', ['cancel', 'refuse']),
             ], limit=1)

--- a/hr_holidays_leave_overlap/tests/__init__.py
+++ b/hr_holidays_leave_overlap/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_leave_overlap

--- a/hr_holidays_leave_overlap/tests/__init__.py
+++ b/hr_holidays_leave_overlap/tests/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_leave_overlap

--- a/hr_holidays_leave_overlap/tests/test_leave_overlap.py
+++ b/hr_holidays_leave_overlap/tests/test_leave_overlap.py
@@ -1,0 +1,202 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.exceptions import ValidationError
+from odoo.tests import common
+from odoo.fields import Datetime
+from datetime import timedelta
+
+
+class TestLeaveOverlap(common.TransactionCase):
+
+    def setUp(self):
+        super(TestLeaveOverlap, self).setUp()
+
+        self.employee_model = self.env['hr.employee']
+        self.user_model = self.env['res.users']
+        self.leave_type_model = self.env['hr.holidays.status']
+        self.leave_request_model = self.env['hr.holidays']
+        self.today = Datetime.from_string(Datetime.now()).replace(
+            hour=0, minute=0, second=0, microsecond=0)
+
+        # Create an employee user to make leave requests
+        self.test_user_id = self.user_model.create({
+            'name': 'Test User',
+            'login': 'test_user',
+            'email': 'mymail@test.com'
+        })
+
+        # Create an employee related to the user to make leave requests
+        self.test_employee_id = self.employee_model.create(
+            {'name': 'Test Employee', 'user_id': self.test_user_id.id})
+
+        # Create 1 leave type
+        self.test_leave_type_id = self.leave_type_model.create(
+            {'name': 'Test Leave Type1'})
+
+        # Create some leave request
+        self.leave_request1 = self.leave_request_model.create({
+            'name': 'Test Leave Request 1',
+            'holiday_status_id': self.test_leave_type_id.id,
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+            'date_from': Datetime.to_string(self.today),
+            'date_to': Datetime.to_string(self.today + timedelta(days=2))
+        })
+
+        self.leave_request2 = self.leave_request_model.create({
+            'name': 'Test Leave Request 2',
+            'holiday_status_id': self.test_leave_type_id.id,
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+            'date_from': Datetime.to_string(self.today + timedelta(days=4)),
+            'date_to': Datetime.to_string(self.today + timedelta(days=7))
+        })
+
+        self.leave_request3 = self.leave_request_model.create({
+            'name': 'Test Leave Request 3',
+            'holiday_status_id': self.test_leave_type_id.id,
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+            'date_from': Datetime.to_string(self.today + timedelta(days=9)),
+            'date_to': Datetime.to_string(self.today + timedelta(days=11))
+        })
+
+    def test_01_left(self):
+        self.leave_request_model.create({
+            'name': 'Test Leave Request A',
+            'holiday_status_id': self.test_leave_type_id.id,
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+            'date_from': Datetime.to_string(self.today - timedelta(days=2)),
+            'date_to': Datetime.to_string(self.today + timedelta(days=1))
+        })
+
+        r = self.leave_request_model.search([
+            ('employee_id','=',self.test_employee_id.id),
+            ('date_from','=', Datetime.to_string(
+                self.today - timedelta(days=2))),
+            ('date_to', '=', Datetime.to_string(
+                self.today - timedelta(seconds=1)))
+        ])
+        self.assertNotEquals(r, False)
+
+    def test_02_right(self):
+        self.leave_request_model.create({
+            'name': 'Test Leave Request B',
+            'holiday_status_id': self.test_leave_type_id.id,
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+            'date_from': Datetime.to_string(
+                self.today + timedelta(days=9)),
+            'date_to': Datetime.to_string(
+                self.today + timedelta(days=12))
+        })
+
+        r = self.leave_request_model.search([
+            ('employee_id','=',self.test_employee_id.id),
+            ('date_from','=', Datetime.to_string(
+                self.today + timedelta(days=11, seconds=1))),
+            ('date_to', '=', Datetime.to_string(
+                self.today + timedelta(days=12)))
+        ])
+        self.assertNotEquals(r, False)
+
+    def test_03_including(self):
+        self.leave_request_model.create({
+            'name': 'Test Leave Request C',
+            'holiday_status_id': self.test_leave_type_id.id,
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+            'date_from': Datetime.to_string(
+                self.today + timedelta(days=3)),
+            'date_to': Datetime.to_string(
+                self.today + timedelta(days=8))
+        })
+
+        r = self.leave_request_model.search([
+            ('employee_id','=',self.test_employee_id.id),
+            ('date_from','=', Datetime.to_string(
+                self.today + timedelta(days=3))),
+            ('date_to', '=', Datetime.to_string(
+                self.today + timedelta(days=4) - timedelta(seconds=1)))
+        ])
+        self.assertNotEquals(r, False)
+
+        r = self.leave_request_model.search([
+            ('employee_id','=',self.test_employee_id.id),
+            ('date_from','=', Datetime.to_string(
+                self.today + timedelta(days=7, seconds=1))),
+            ('date_to', '=', Datetime.to_string(
+                self.today + timedelta(days=8)))
+        ])
+        self.assertNotEquals(r, False)
+
+    def test_04_included(self):
+        with self.assertRaises(ValidationError):
+            self.leave_request_model.create({
+                'name': 'Test Leave Request D',
+                'holiday_status_id': self.test_leave_type_id.id,
+                'holiday_type': 'employee',
+                'employee_id': self.test_employee_id.id,
+                'type': 'remove',
+                'date_from': Datetime.to_string(
+                    self.today + timedelta(days=5)),
+                'date_to': Datetime.to_string(
+                    self.today + timedelta(days=6))
+            })
+
+    def test_05_all(self):
+        self.leave_request_model.create({
+            'name': 'Test Leave Request E',
+            'holiday_status_id': self.test_leave_type_id.id,
+            'holiday_type': 'employee',
+            'employee_id': self.test_employee_id.id,
+            'type': 'remove',
+            'date_from': Datetime.to_string(
+                self.today - timedelta(days=1)),
+            'date_to': Datetime.to_string(
+                self.today + timedelta(days=13))
+        })
+
+        r = self.leave_request_model.search([
+            ('employee_id','=',self.test_employee_id.id),
+            ('date_from','=', Datetime.to_string(
+                self.today - timedelta(days=1))),
+            ('date_to', '=', Datetime.to_string(
+                self.today - timedelta(seconds=1)))
+        ])
+        self.assertNotEquals(r, False)
+
+        r = self.leave_request_model.search([
+            ('employee_id','=',self.test_employee_id.id),
+            ('date_from','=', Datetime.to_string(
+                self.today + timedelta(days=2, seconds=1))),
+            ('date_to', '=', Datetime.to_string(
+                self.today + timedelta(days=4) - timedelta(seconds=1)))
+        ])
+        self.assertNotEquals(r, False)
+
+        r = self.leave_request_model.search([
+            ('employee_id','=',self.test_employee_id.id),
+            ('date_from','=', Datetime.to_string(
+                self.today + timedelta(days=7, seconds=1))),
+            ('date_to', '=', Datetime.to_string(
+                self.today + timedelta(days=9) - timedelta(seconds=1)))
+        ])
+        self.assertNotEquals(r, False)
+
+        r = self.leave_request_model.search([
+            ('employee_id','=',self.test_employee_id.id),
+            ('date_from','=', Datetime.to_string(
+                self.today + timedelta(days=11, seconds=1))),
+            ('date_to', '=', Datetime.to_string(
+                self.today + timedelta(days=13)))
+        ])
+        self.assertNotEquals(r, False)

--- a/hr_holidays_leave_overlap/tests/test_leave_overlap.py
+++ b/hr_holidays_leave_overlap/tests/test_leave_overlap.py
@@ -77,8 +77,8 @@ class TestLeaveOverlap(common.TransactionCase):
         })
 
         r = self.leave_request_model.search([
-            ('employee_id','=',self.test_employee_id.id),
-            ('date_from','=', Datetime.to_string(
+            ('employee_id', '=', self.test_employee_id.id),
+            ('date_from', '=', Datetime.to_string(
                 self.today - timedelta(days=2))),
             ('date_to', '=', Datetime.to_string(
                 self.today - timedelta(seconds=1)))
@@ -99,8 +99,8 @@ class TestLeaveOverlap(common.TransactionCase):
         })
 
         r = self.leave_request_model.search([
-            ('employee_id','=',self.test_employee_id.id),
-            ('date_from','=', Datetime.to_string(
+            ('employee_id', '=', self.test_employee_id.id),
+            ('date_from', '=', Datetime.to_string(
                 self.today + timedelta(days=11, seconds=1))),
             ('date_to', '=', Datetime.to_string(
                 self.today + timedelta(days=12)))
@@ -121,8 +121,8 @@ class TestLeaveOverlap(common.TransactionCase):
         })
 
         r = self.leave_request_model.search([
-            ('employee_id','=',self.test_employee_id.id),
-            ('date_from','=', Datetime.to_string(
+            ('employee_id', '=', self.test_employee_id.id),
+            ('date_from', '=', Datetime.to_string(
                 self.today + timedelta(days=3))),
             ('date_to', '=', Datetime.to_string(
                 self.today + timedelta(days=4) - timedelta(seconds=1)))
@@ -130,8 +130,8 @@ class TestLeaveOverlap(common.TransactionCase):
         self.assertNotEquals(r, False)
 
         r = self.leave_request_model.search([
-            ('employee_id','=',self.test_employee_id.id),
-            ('date_from','=', Datetime.to_string(
+            ('employee_id', '=', self.test_employee_id.id),
+            ('date_from', '=', Datetime.to_string(
                 self.today + timedelta(days=7, seconds=1))),
             ('date_to', '=', Datetime.to_string(
                 self.today + timedelta(days=8)))
@@ -166,8 +166,8 @@ class TestLeaveOverlap(common.TransactionCase):
         })
 
         r = self.leave_request_model.search([
-            ('employee_id','=',self.test_employee_id.id),
-            ('date_from','=', Datetime.to_string(
+            ('employee_id', '=', self.test_employee_id.id),
+            ('date_from', '=', Datetime.to_string(
                 self.today - timedelta(days=1))),
             ('date_to', '=', Datetime.to_string(
                 self.today - timedelta(seconds=1)))
@@ -175,8 +175,8 @@ class TestLeaveOverlap(common.TransactionCase):
         self.assertNotEquals(r, False)
 
         r = self.leave_request_model.search([
-            ('employee_id','=',self.test_employee_id.id),
-            ('date_from','=', Datetime.to_string(
+            ('employee_id', '=', self.test_employee_id.id),
+            ('date_from', '=', Datetime.to_string(
                 self.today + timedelta(days=2, seconds=1))),
             ('date_to', '=', Datetime.to_string(
                 self.today + timedelta(days=4) - timedelta(seconds=1)))
@@ -184,8 +184,8 @@ class TestLeaveOverlap(common.TransactionCase):
         self.assertNotEquals(r, False)
 
         r = self.leave_request_model.search([
-            ('employee_id','=',self.test_employee_id.id),
-            ('date_from','=', Datetime.to_string(
+            ('employee_id', '=', self.test_employee_id.id),
+            ('date_from', '=', Datetime.to_string(
                 self.today + timedelta(days=7, seconds=1))),
             ('date_to', '=', Datetime.to_string(
                 self.today + timedelta(days=9) - timedelta(seconds=1)))
@@ -193,8 +193,8 @@ class TestLeaveOverlap(common.TransactionCase):
         self.assertNotEquals(r, False)
 
         r = self.leave_request_model.search([
-            ('employee_id','=',self.test_employee_id.id),
-            ('date_from','=', Datetime.to_string(
+            ('employee_id', '=', self.test_employee_id.id),
+            ('date_from', '=', Datetime.to_string(
                 self.today + timedelta(days=11, seconds=1))),
             ('date_to', '=', Datetime.to_string(
                 self.today + timedelta(days=13)))


### PR DESCRIPTION
This modules allows holiday leaves overlap, automatically handling them, adapting or splitting the new leave request in order to arrange it in a time period where other leaves were already registered.