### PR TITLE
[10.0][hr_attendance_rfid]

### DIFF
--- a/hr_attendance_rfid/README.rst
+++ b/hr_attendance_rfid/README.rst
@@ -1,0 +1,73 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================
+HR Attendance RFID
+==================
+
+This module extends the functionality of HR Attendance in order to allow
+the logging of employee attendances using an RFID based employee
+attendance system.
+
+Configuration
+=============
+
+To use this module, you need to use an external system that calls the method
+'register_attendance' of the model 'hr.employee' passing as parameter the
+code of the RFID card.
+
+Developers of a compatible RFID based employee attendance system should
+be familiar with the outputs of this method and implement proper calls and
+management of responses.
+
+It is advisory to create an exclusive user to perform this task. As
+user doesn't need several access, it is just essential to perform the check
+in/out, a group has been created. Add your attendance device user to
+RFID Attendance group.
+
+Usage
+=====
+
+#. The HR employee responsible to set up new employees should go to
+   'Attendances -> Manage Attendances -> Employees' and register the
+   RFID card code of each of your employees. You can use an USB plugged
+   RFID reader connected to your computer for this purpose.
+#. The employee should put his/her card to the RFID based employee
+   attendance system. It is expected that the system will provide some form
+   of output of the registration event.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Omar Catiñeira Saavedra <omar@comunitea.com>
+* Héctor Villarreal Ortega <hector.villarreal@eficent.com>
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+    :alt: Odoo Community Association
+    :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/hr_attendance_rfid/__init__.py
+++ b/hr_attendance_rfid/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/hr_attendance_rfid/__manifest__.py
+++ b/hr_attendance_rfid/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Comunitea Servicios Tecnológicos S.L.
+# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    'name': 'HR Attendance RFID',
+    'version': '10.0.1.0.0',
+    'category': 'Human Resources',
+    'website': 'https://github.com/OCA/hr',
+    'author': 'Comunitea,'
+              'Eficent,'
+              'Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'application': False,
+    'installable': True,
+    'depends': [
+        'hr_attendance',
+    ],
+    'data': [
+        'views/hr_employee_view.xml',
+        'security/hr_attendance_rfid.xml',
+        'security/ir.model.access.csv',
+    ],
+}

--- a/hr_attendance_rfid/models/__init__.py
+++ b/hr_attendance_rfid/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import hr_employee

--- a/hr_attendance_rfid/models/hr_employee.py
+++ b/hr_attendance_rfid/models/hr_employee.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Comunitea Servicios Tecnológicos S.L.
+# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import logging
+from odoo import api, models, fields, _
+_logger = logging.getLogger(__name__)
+
+
+class HrEmployee(models.Model):
+
+    _inherit = "hr.employee"
+    _sql_constraints = [(
+        'rfid_card_code_uniq',
+        'UNIQUE(rfid_card_code)',
+        'The rfid code should be unique.'
+    )]
+
+    rfid_card_code = fields.Char("RFID Card Code")
+
+    @api.model
+    def register_attendance(self, card_code):
+        """ Register the attendance of the employee.
+        :returns: dictionary
+            'rfid_card_code': char
+            'employee_name': char
+            'employee_id': int
+            'error_message': char
+            'logged': boolean
+            'action': check_in/check_out
+        """
+
+        res = {
+            'rfid_card_code': card_code,
+            'employee_name': '',
+            'employee_id': False,
+            'error_message': '',
+            'logged': False,
+            'action': 'FALSE',
+        }
+        employee = self.search([('rfid_card_code', '=', card_code)], limit=1)
+        if employee:
+            res['employee_name'] = employee.name
+            res['employee_id'] = employee.id
+        else:
+            msg = _("No employee found with card %s") % card_code
+            _logger.warning(msg)
+            res['error_message'] = msg
+            return res
+        try:
+            attendance = employee.attendance_action_change()
+            if attendance:
+                msg = _('Attendance recorded for employee %s') % employee.name
+                _logger.debug(msg)
+                res['logged'] = True
+                if attendance.check_out:
+                    res['action'] = 'check_out'
+                else:
+                    res['action'] = 'check_in'
+                return res
+            else:
+                msg = _('No attendance was recorded for '
+                        'employee %s') % employee.name
+                _logger.debug(msg)
+                res['error_message'] = msg
+                return res
+        except Exception as e:
+            msg = e.message
+            _logger.error(msg)
+            res['error_message'] = msg
+        return res

--- a/hr_attendance_rfid/security/hr_attendance_rfid.xml
+++ b/hr_attendance_rfid/security/hr_attendance_rfid.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <record id="group_hr_attendance_rfid" model="res.groups">
+            <field name="name">RFID Attendance</field>
+            <field name="category_id" ref="base.module_category_hr_attendance"/>
+        </record>
+    </data>
+</odoo>

--- a/hr_attendance_rfid/security/ir.model.access.csv
+++ b/hr_attendance_rfid/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hr_attendance_rfid,access.hr.attendance.rfid,hr_attendance.model_hr_attendance,hr_attendance_rfid.group_hr_attendance_rfid,1,1,1,0
+access_hr_employee_rfid,access.hr.employee.rfid,model_hr_employee,hr_attendance_rfid.group_hr_attendance_rfid,1,0,0,0
+access_resources_resource_rfid,access.resource.resource.rfid,resource.model_resource_resource,hr_attendance_rfid.group_hr_attendance_rfid,1,0,0,0

--- a/hr_attendance_rfid/tests/__init__.py
+++ b/hr_attendance_rfid/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import test_hr_attendance_rfid_process
+

--- a/hr_attendance_rfid/tests/test_hr_attendance_rfid_process.py
+++ b/hr_attendance_rfid/tests/test_hr_attendance_rfid_process.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests.common import TransactionCase
+
+
+class TestHrAttendance(TransactionCase):
+
+    def setUp(self):
+        super(TestHrAttendance, self).setUp()
+        self.employee_model = self.env['hr.employee']
+        self.test_employee = self.browse_ref('hr.employee_al')
+        self.rfid_card_code = '5b3f5'
+        self.test_employee.rfid_card_code = self.rfid_card_code
+
+    def test_valid_employee(self):
+        """Valid employee"""
+        res = self.employee_model.register_attendance(
+            self.rfid_card_code)
+        self.assertTrue('action' in res and res['action'] == 'check_in')
+        self.assertTrue('logged' in res and res['logged'])
+        self.assertTrue(
+            'rfid_card_code' in res and
+            res['rfid_card_code'] == self.rfid_card_code)
+        res = self.employee_model.register_attendance(
+            self.rfid_card_code)
+        self.assertTrue('action' in res and res['action'] == 'check_out')
+        self.assertTrue('logged' in res and res['logged'])
+
+    def test_invalid_code(self):
+        """Invalid employee"""
+        invalid_code = '029238d'
+        res = self.employee_model.register_attendance(invalid_code)
+        self.assertTrue('action' in res and res['action'] == 'FALSE')
+        self.assertTrue('logged' in res and not res['logged'])
+        self.assertTrue(
+            'rfid_card_code' in res and
+            res['rfid_card_code'] == invalid_code)

--- a/hr_attendance_rfid/views/hr_employee_view.xml
+++ b/hr_attendance_rfid/views/hr_employee_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_employee_form_add_rfid" model="ir.ui.view">
+        <field name="name">hr.employee.form.add_rfid</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr_attendance.view_employee_form_inherit_hr_attendance"/>
+        <field name="arch" type="xml">
+             <field name="pin" position="after">
+                <field name="rfid_card_code" groups="hr_attendance.group_hr_attendance_user"/>
+             </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
HR Attendance RFID
==================

This module extends the functionality of HR Attendance in order to allow
the logging of employee attendances using an RFID based employee
attendance system.

Configuration
=============

To use this module, you need to use an external system that calls the method
'register_attendance' of the model 'hr.employee' passing as parameter the
code of the RFID card.

Developers of a compatible RFID based employee attendance system should
familiarise with the outputs of this method and implement proper calls and
management of responses.


Usage
=====

#. The HR employee responsible to set up new employees should go to
   'Attendances -> Manage Attendances -> Employees' and register the
   RFID card code of each of your employees. You can use an USB plugged
   RFID reader connected to your computer for this purpose.
#. The employee should approach her card to the RFID based employee
   attendance system. It is expected that the system will provide some form
   of output of the registration event.