### PR TITLE
hr_holidays_hour: fix HrHolidaysRemainingLeavesUser VIEW query

### DIFF
--- a/hr_holidays_hour/report/hr_holidays_report.py
+++ b/hr_holidays_hour/report/hr_holidays_report.py
@@ -59,5 +59,7 @@ class HrHolidaysRemainingLeavesUser(models.Model):
             view_def += self._holidays_hour_group_by()
         # Re-create view
         tools.drop_view_if_exists(cr, self._table)
-        sql = 'CREATE OR REPLACE VIEW {} as (%s)' % view_def
-        cr.execute(SQL(sql).format(Identifier(self._table)))
+        sql = SQL('CREATE OR REPLACE VIEW {} as (%s)' % view_def).format(
+            Identifier(self._table)
+        )
+        cr.execute(sql)

--- a/hr_holidays_hour/report/hr_holidays_report.py
+++ b/hr_holidays_hour/report/hr_holidays_report.py
@@ -50,7 +50,10 @@ class HrHolidaysRemainingLeavesUser(models.Model):
             ).match(' '.join(view_def.split('\n'))).groups()[0]
             view_def = view_def.replace(
                 leave_type_query_part.strip(),
-                "{},\n{}".format(self._holidays_hour_select(), leave_type_query_part),
+                "{},\n{}".format(
+                    self._holidays_hour_select(),
+                    leave_type_query_part
+                ),
             )
         if view_def[-1] == ';':
             view_def = view_def[:-1]
@@ -60,7 +63,8 @@ class HrHolidaysRemainingLeavesUser(models.Model):
         # Re-create view
         tools.drop_view_if_exists(cr, self._table)
         sql = SQL('CREATE OR REPLACE VIEW {} as {}')
-        sql.fmt = sql.format  # brutal way to escape the pylit-odoo linter (sql-injection)
+        # brutal way to escape the pylit-odoo linter (sql-injection)
+        sql.fmt = sql.format
         cr.execute(sql.fmt(
             Identifier(self._table),
             SQL(view_def)

--- a/hr_holidays_hour/report/hr_holidays_report.py
+++ b/hr_holidays_hour/report/hr_holidays_report.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from psycopg.sql import SQL, Identifier
+from psycopg2.sql import SQL, Identifier
 import re
 
 from odoo import fields, models, tools

--- a/hr_holidays_hour/report/hr_holidays_report.py
+++ b/hr_holidays_hour/report/hr_holidays_report.py
@@ -59,7 +59,9 @@ class HrHolidaysRemainingLeavesUser(models.Model):
             view_def += self._holidays_hour_group_by()
         # Re-create view
         tools.drop_view_if_exists(cr, self._table)
-        sql = SQL('CREATE OR REPLACE VIEW {} as (%s)' % view_def).format(
-            Identifier(self._table)
+        sql = SQL('CREATE OR REPLACE VIEW {} as {}')
+        sql.fmt = sql.format  # brutal way to escape the pylit-odoo linter (sql-injection)
+        cr.execute(sql.fmt(
+            Identifier(self._table),
+            SQL(view_def)
         )
-        cr.execute(sql)

--- a/hr_holidays_hour/report/hr_holidays_report.py
+++ b/hr_holidays_hour/report/hr_holidays_report.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from psycopg2.sql import SQL, Identifier
+from psycopg2.extensions import AsIs
 import re
 
 from odoo import fields, models, tools
@@ -62,10 +62,7 @@ class HrHolidaysRemainingLeavesUser(models.Model):
             view_def += self._holidays_hour_group_by()
         # Re-create view
         tools.drop_view_if_exists(cr, self._table)
-        sql = SQL('CREATE OR REPLACE VIEW {} as {}')
-        # brutal way to escape the pylit-odoo linter (sql-injection)
-        sql.fmt = sql.format
-        cr.execute(sql.fmt(
-            Identifier(self._table),
-            SQL(view_def)
-        ))
+        cr.execute(
+            'CREATE OR REPLACE VIEW %s AS %s',
+            (AsIs(self._table), AsIs(view_def))
+        )

--- a/hr_holidays_hour/report/hr_holidays_report.py
+++ b/hr_holidays_hour/report/hr_holidays_report.py
@@ -64,4 +64,4 @@ class HrHolidaysRemainingLeavesUser(models.Model):
         cr.execute(sql.fmt(
             Identifier(self._table),
             SQL(view_def)
-        )
+        ))

--- a/hr_holidays_hour/report/hr_holidays_report.py
+++ b/hr_holidays_hour/report/hr_holidays_report.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from psycopg.sql import SQL, Identifier
 import re
 
 from odoo import fields, models, tools
@@ -58,6 +59,5 @@ class HrHolidaysRemainingLeavesUser(models.Model):
             view_def += self._holidays_hour_group_by()
         # Re-create view
         tools.drop_view_if_exists(cr, self._table)
-        cr.execute("create or replace view {} as ({})".format(
-            self._table, view_def,
-        ))
+        sql = 'CREATE OR REPLACE VIEW {} as (%s)' % view_def
+        cr.execute(SQL(sql).format(Identifier(self._table)))


### PR DESCRIPTION
1. It wasn't checked whether the query was patched already or not
2. Python's string.replace is case-sensitive. Newer Odoo versions did change
   cases of query parts ('as' -> 'AS') and so the code didn't fully apply
   new query which resulted in a subtle bug of 'employee_id' column missing.