### PR TITLE
[10.0][ADD] hr_public_holidays : Allow to change dates in wizard

### DIFF
--- a/hr_public_holidays/README.rst
+++ b/hr_public_holidays/README.rst
@@ -79,6 +79,7 @@ Contributors
 * Tecnativa - Pedro M. Baeza
 * Nedas Zilinskas <nedas.zilinskas@xpansa.com> (Ventor, Xpansa Group <https://ventor.tech/>)
 * Artem Kostyuk <a.kostyuk@mobilunity.com>
+* Akim Juillerat <akim.juillerat@camptocamp.com>
 
 Maintainer
 ----------

--- a/hr_public_holidays/wizards/public_holidays_next_year_wizard.py
+++ b/hr_public_holidays/wizards/public_holidays_next_year_wizard.py
@@ -52,18 +52,17 @@ class PublicHolidaysNextYearWizard(models.TransientModel):
             else:
                 last_ph_dict[ph.country_id] = ph
 
-        new_ph_ids = []
+        all_new_ph_values = []
+
         for last_ph in last_ph_dict.itervalues():
 
             new_year = self.year or last_ph.year + 1
 
-            new_ph_vals = {
+            new_ph_vals = last_ph.copy_data({
                 'year': new_year,
-            }
+            })[0]
 
-            new_ph = last_ph.copy(new_ph_vals)
-
-            new_ph_ids.append(new_ph.id)
+            line_values = []
 
             for last_ph_line in last_ph.line_ids:
                 ph_line_date = fields.Date.from_string(last_ph_line.date)
@@ -85,11 +84,19 @@ class PublicHolidaysNextYearWizard(models.TransientModel):
 
                 new_date = ph_line_date.replace(year=new_year)
 
-                new_ph_line_vals = {
+                new_line_vals = last_ph_line.copy_data({
                     'date': new_date,
-                    'year_id': new_ph.id,
-                }
-                last_ph_line.copy(new_ph_line_vals)
+                })[0]
+                new_line_vals.pop('year_id')
+                line_values.append((0, 0, new_line_vals))
+
+            new_ph_vals['line_ids'] = line_values
+            all_new_ph_values.append(new_ph_vals)
+
+        new_ph_ids = []
+        for new_ph_to_create in all_new_ph_values:
+            new_ph = ph_env.create(new_ph_to_create)
+            new_ph_ids.append(new_ph.id)
 
         domain = [['id', 'in', new_ph_ids]]
 

--- a/hr_public_holidays/wizards/public_holidays_next_year_wizard.py
+++ b/hr_public_holidays/wizards/public_holidays_next_year_wizard.py
@@ -26,6 +26,31 @@ class PublicHolidaysNextYearWizard(models.TransientModel):
         help='Year for which you want to create the public holidays. '
         'By default, the year following the template.',
     )
+    public_holidays_next_year_day_ids = fields.One2many(
+        comodel_name='public.holidays.next.year.day.wiz',
+        inverse_name='public_holidays_next_year_wizard_id',
+        string='Next year public holidays to create',
+        help="Define next year's holiday dates",
+    )
+
+    @api.onchange('template_ids', 'year')
+    def onchange_year_template_ids(self):
+        self.ensure_one()
+        self.public_holidays_next_year_day_ids = False
+        for template in self.template_ids:
+            for line in template.line_ids:
+                last_date = fields.Date.from_string(line.date)
+                new_year = self.year or template.year + 1
+                new_day = self.env[
+                    'public.holidays.next.year.day.wiz'].new({
+                        'public_holidays_next_year_wizard_id': self.id,
+                        'template_id': template.id,
+                        'name': line.name,
+                        'variable': line.variable,
+                        'last_date': line.date,
+                        'next_date': last_date.replace(year=new_year),
+                    })
+                self.public_holidays_next_year_day_ids |= new_day
 
     @api.multi
     def create_public_holidays(self):
@@ -81,8 +106,20 @@ class PublicHolidaysNextYearWizard(models.TransientModel):
                         'includes public holidays on 29th of February '
                         '(2016, 2020...), please select a template from '
                         'another year.'))
-
-                new_date = ph_line_date.replace(year=new_year)
+                # If options were used to define next years public holidays
+                # we look for a matching day
+                if self.public_holidays_next_year_day_ids:
+                    matching = self.public_holidays_next_year_day_ids.filtered(
+                        lambda l: l.last_date == last_ph_line.date)
+                    # If no match is found, it means the user did delete this
+                    # day so we don't want to create it
+                    if not matching:
+                        continue
+                    else:
+                        new_date = matching.next_date
+                # If options were not used, keep std behaviour
+                else:
+                    new_date = ph_line_date.replace(year=new_year)
 
                 new_line_vals = last_ph_line.copy_data({
                     'date': new_date,
@@ -109,3 +146,33 @@ class PublicHolidaysNextYearWizard(models.TransientModel):
         }
 
         return action
+
+
+class HrHolidaysPublicLineVariable(models.TransientModel):
+
+    _name = 'public.holidays.next.year.day.wiz'
+
+    public_holidays_next_year_wizard_id = fields.Many2one(
+        'public.holidays.next.year.wizard',
+        readonly=True,
+    )
+    template_id = fields.Many2one(
+        'hr.holidays.public',
+        string='Template',
+        required=True,
+        readonly=True,
+    )
+    name = fields.Char(
+        required=True,
+        readonly=True,
+    )
+    last_date = fields.Date(
+        required=True,
+        readonly=True,
+    )
+    variable = fields.Boolean(
+        readonly=True,
+    )
+    next_date = fields.Date(
+        required=True,
+    )

--- a/hr_public_holidays/wizards/public_holidays_next_year_wizard.xml
+++ b/hr_public_holidays/wizards/public_holidays_next_year_wizard.xml
@@ -27,22 +27,36 @@
                         for each country are used as template to create  
                         public holidays for the year following the templates.
                         <br/><br/>
-                        Normally, you should not need to input anything in 
-                        optional fields and only need to click on the button 
-                        "Create".
-                        </div> 
+                        Should you want to modify the public holidays to be
+                        created, e.g for public holidays having variable date,
+                        please use the optional pane.
+                        </div>
                     </page>
-                    <page name="optional" string="Optional">
+                    <page name="manual" string="Manual">
                         <div>
-                        The below optional fields are here only to handle 
-                        special situations like "2011 was a special year with 
-                        an additional public holiday for the 150th 
-                        anniversary of the Italian unification, so you want to 
-                        replicate the 2010 Italian holidays to 2012."
+                        The fields below are here to manually handle the creation
+                        of public holidays.
+                        Select first the template to be used to create next year's
+                        public holidays.
+                        You can define the target year in which you want to create
+                        the holidays, but default value is the year following the
+                        template's year.
+                        The public holidays to be created are then displayed to
+                        allow you modification of the date in case of public
+                        holidays having a variable date (highlighted in red).
                         </div>
                         <group>
                             <field name="template_ids" />
                             <field name="year" />
+                            <field name="public_holidays_next_year_day_ids">
+                                <tree decoration-danger="variable" decoration-info="not variable" editable="1" create="false" >
+                                    <field name="template_id" />
+                                    <field name="name" />
+                                    <field name="variable" />
+                                    <field name="last_date" />
+                                    <field name="next_date" />
+                                </tree>
+                            </field>
                         </group>
                     </page>
                 </notebook>


### PR DESCRIPTION
When creating next year's public holidays using the wizard, holidays being flagged
with variable=True (Date may change) were created using last year's date although
this date will not be the same in 99% of the cases.
This commit adds a new model with an onchange to allow the user to set next years
holiday date in the wizard before the creation of related holidays.

Based on :
 - [x] #508 

TODO :
 - [x] Add tests
 - [ ] Add a function to compute easter related days ? Not sure it's right to do it here though :thinking: 