### PR TITLE
[ADD] migration script for hr_emergency_contact

### DIFF
--- a/hr_emergency_contact/migrations/10.0.1.0.0/pre-migration.py
+++ b/hr_emergency_contact/migrations/10.0.1.0.0/pre-migration.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Therp BV <https://therp.nl>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version=None):
+    cr.execute(
+        'alter table rel_employee_emergency_contact '
+        'rename column employee_id to hr_employee_id'
+    )
+    cr.execute(
+        'alter table rel_employee_emergency_contact '
+        'rename column partner_id to res_partner_id'
+    )


### PR DESCRIPTION
transitioning from https://github.com/OCA/hr/blob/9.0/hr_emergency_contact/models/hr_employee.py#L16 to https://github.com/OCA/hr/blob/10.0/hr_emergency_contact/models/hr_employee.py#L16 we need a migration script as Odoo's autogenerated names derive from the model name. Adding those parameters afterwards would be worse, then we'd need migration scripts for 10 and 11.