### PR TITLE
[10.0][FIX] mute exeptions, pylint improvements

### DIFF
--- a/hr_attendance_reason/data/hr_attendance_reason_data.xml
+++ b/hr_attendance_reason/data/hr_attendance_reason_data.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
+
     <record id="hr_act_reason_1" model="hr.attendance.reason">
         <field name="name">Manager Manual Amend</field>
         <field name="code">MMA</field>
@@ -18,13 +19,14 @@
         <field name="name">Bad Weather</field>
         <field name="code">BW</field>
     </record>
-    <record id="hr_act_reason_4" model="hr.attendance.reason">
+    <record id="hr_act_reason_5" model="hr.attendance.reason">
         <field name="name">Bad Weather</field>
         <field name="code">BW</field>
     </record>
-    <record id="hr_act_reason_5" model="hr.attendance.reason">
+    <record id="hr_act_reason_6" model="hr.attendance.reason">
         <field name="name">Public Transport Strike</field>
         <field name="code">PTS</field>
         <field name="action_type">sign_in</field>
     </record>
+
 </odoo>

--- a/hr_attendance_rfid/tests/test_hr_attendance_rfid_process.py
+++ b/hr_attendance_rfid/tests/test_hr_attendance_rfid_process.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2018 Eficent Business and IT Consulting Services, S.L.
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 

--- a/hr_employee_firstname/views/hr_view.xml
+++ b/hr_employee_firstname/views/hr_view.xml
@@ -4,6 +4,7 @@
     <record id="view_employee_form" model="ir.ui.view">
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
+        <field name="priority">400</field>
         <field name="arch" type="xml">
             <xpath expr="//label[@for='name']" position="replace">
                 <label for="firstname" class="oe_edit_only"/>

--- a/hr_employee_id/models/hr_employee.py
+++ b/hr_employee_id/models/hr_employee.py
@@ -6,7 +6,7 @@
 import random
 import string
 from odoo import models, fields, api, _
-from odoo.exceptions import Warning as UserWarning
+from odoo.exceptions import Warning as UserError
 
 
 class HrEmployee(models.Model):
@@ -46,7 +46,7 @@ class HrEmployee(models.Model):
                     break
                 tries += 1
             if tries == max_tries:
-                raise UserWarning(_('Unable to generate an Employee ID number that \
+                raise UserError(_('Unable to generate an Employee ID number that \
                 is unique.'))
         return employee_id
 

--- a/hr_employee_legacy_id/models/hr.py
+++ b/hr_employee_legacy_id/models/hr.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 #
 #    Copyright (C) 013 Michael Telahun Makonnen <mmakonnen@gmail.com>.
@@ -22,7 +22,7 @@
 from odoo import fields, models
 
 
-class hr_employee(models.Model):
+class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
     legacy_no = fields.Char('Legacy ID')

--- a/hr_employee_seniority/models/hr_employee.py
+++ b/hr_employee_seniority/models/hr_employee.py
@@ -6,7 +6,7 @@
 import calendar
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, exceptions, fields, models
+from odoo import api, exceptions, fields, models, _
 
 
 class HrEmployee(models.Model):
@@ -80,6 +80,6 @@ class HrEmployee(models.Model):
             first_contract_dt = fields.Date.from_string(
                 self._first_contract().date_start)
             if initial_dt > first_contract_dt:
-                raise exceptions.UserError("The initial employment date cannot"
-                                           " be after the first contract in "
-                                           "the system!")
+                raise exceptions.UserError(_("The initial employment date "
+                                             "cannot be after the first "
+                                             "contract in the system!"))

--- a/hr_family/__manifest__.py
+++ b/hr_family/__manifest__.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 #
 #    Copyright (C) 2011,2013 Michael Telahun Makonnen <mmakonnen@gmail.com>.

--- a/hr_family/models/__init__.py
+++ b/hr_family/models/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 #
 #    Copyright (C) 2011 Michael Telahun Makonnen <mmakonnen@gmail.com>.

--- a/hr_family/models/hr_children.py
+++ b/hr_family/models/hr_children.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 #
 #    Copyright (C) 2011,2013 Michael Telahun Makonnen <mmakonnen@gmail.com>.

--- a/hr_family/models/hr_employee.py
+++ b/hr_family/models/hr_employee.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 #
 #    Copyright (C) 2011,2013 Michael Telahun Makonnen <mmakonnen@gmail.com>.

--- a/hr_holidays_hour/models/hr_holidays.py
+++ b/hr_holidays_hour/models/hr_holidays.py
@@ -5,7 +5,8 @@
 import datetime
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError, Warning
+from odoo.exceptions import ValidationError
+from odoo.exceptions import Warning as UserError
 
 
 class HrHolidays(models.Model):
@@ -58,7 +59,7 @@ class HrHolidays(models.Model):
         # date_to has to be greater than date_from
         if self.date_from and self.date_to:
             if self.date_from > self.date_to:
-                raise Warning(_(
+                raise UserError(_(
                     'The start date must be anterior to the end date.'
                 ))
 
@@ -67,7 +68,7 @@ class HrHolidays(models.Model):
         self.ensure_one()
         employee = self.employee_id
         if not employee and (self.date_to or self.date_from):
-            raise Warning(_('Set an employee first!'))
+            raise UserError(_('Set an employee first!'))
 
     @api.multi
     def _compute_work_hours(self, from_dt, to_dt):

--- a/hr_holidays_hour/tests/test_leave_hours.py
+++ b/hr_holidays_hour/tests/test_leave_hours.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from odoo.tests import common
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT as DF
-from odoo.exceptions import Warning, ValidationError
+from odoo.exceptions import ValidationError
+from odoo.exceptions import Warning as UserError
 
 
 class TestLeaveHours(common.TransactionCase):
@@ -196,9 +197,9 @@ class TestLeaveHours(common.TransactionCase):
             'date_to': self.holiday_start.strftime(DF),
         }
 
-        with self.assertRaises(Warning):
+        with self.assertRaises(UserError):
             self.leave_1.onchange(values, 'date_from', field_onchange)
-        with self.assertRaises(Warning):
+        with self.assertRaises(UserError):
             self.leave_1.onchange(values, 'date_to', field_onchange)
 
         values.update({
@@ -209,9 +210,9 @@ class TestLeaveHours(common.TransactionCase):
 
         self.leave_1.onchange(values, 'employee_id', field_onchange)
 
-        with self.assertRaises(Warning):
+        with self.assertRaises(UserError):
             self.leave_1.onchange(values, 'date_from', field_onchange)
-        with self.assertRaises(Warning):
+        with self.assertRaises(UserError):
             self.leave_1.onchange(values, 'date_to', field_onchange)
 
     def test_03_creation_fail(self):

--- a/hr_holidays_imposed_days/models/hr_imposed_holidays.py
+++ b/hr_holidays_imposed_days/models/hr_imposed_holidays.py
@@ -113,9 +113,9 @@ class HrHolidaysImposed(models.Model):
     def compute_nb_days(self, diff):
         return round(math.floor(diff))+1
 
-    @api.one
     @api.constrains('date_from', 'date_to')
     def _check_dates(self):
+        self.ensure_one()
         if ((self.date_from and self.date_to) and
                 (self.date_from > self.date_to)):
             raise ValidationError(_(

--- a/hr_holidays_meeting_name/views/hr_holidays_view.xml
+++ b/hr_holidays_meeting_name/views/hr_holidays_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
    <record id="edit_holiday_status_form" model="ir.ui.view">
         <field name="name">hr.holidays.status.form (hr_holidays_meeting_name)</field>
         <field name="model">hr.holidays.status</field>
@@ -11,4 +12,5 @@
             </xpath>
         </field>
     </record>
+
 </odoo>

--- a/hr_holidays_validity_date/tests/test_hr_holidays_validity_date.py
+++ b/hr_holidays_validity_date/tests/test_hr_holidays_validity_date.py
@@ -27,9 +27,13 @@ from odoo.tests import common
 from odoo import exceptions
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from datetime import datetime, timedelta
+from odoo.tools import mute_logger
 
 
 class TestHrHolidaysValidityDate(common.TransactionCase):
+
+    at_install = False
+    post_install = True
 
     def setUp(self):
         super(TestHrHolidaysValidityDate, self).setUp()
@@ -55,7 +59,7 @@ class TestHrHolidaysValidityDate(common.TransactionCase):
             'holiday_status_id': self.type01.id,
             'date_from': today,
             'date_to': tommorow,
-            'number_of_days_temp': 2,
+            'number_of_days_temp': 1,
         }
         self.holidays_obj.create(leave_vals)
 
@@ -84,6 +88,7 @@ class TestHrHolidaysValidityDate(common.TransactionCase):
             'date_to': tommorow,
             'number_of_days_temp': 2,
         }
-        with self.assertRaises(exceptions.ValidationError),\
-                self.cr.savepoint():
-            self.holidays_obj.create(leave_vals)
+        with mute_logger('odoo.models'):
+            with self.assertRaises(exceptions.ValidationError),\
+                    self.cr.savepoint():
+                self.holidays_obj.create(leave_vals)

--- a/hr_payroll_cancel/models/hr_payroll.py
+++ b/hr_payroll_cancel/models/hr_payroll.py
@@ -7,7 +7,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-from odoo.tools.safe_eval import safe_eval as eval
+from odoo.tools.safe_eval import safe_eval
 
 
 class HrPayslip(models.Model):
@@ -22,7 +22,7 @@ class HrPayslip(models.Model):
     @api.multi
     def refund_sheet(self):
         res = super(HrPayslip, self).refund_sheet()
-        self.refunded_id = eval(res['domain'])[0][2][0] or False
+        self.refunded_id = safe_eval(res['domain'])[0][2][0] or False
         return res
 
     @api.multi

--- a/hr_period/__manifest__.py
+++ b/hr_period/__manifest__.py
@@ -19,6 +19,7 @@
     'data': [
         'data/ir_sequence_data.xml',
         'data/date_range_type.xml',
+        'security/hr_period_security.xml',
         'security/ir.model.access.csv',
         'views/hr_period_view.xml',
         'views/hr_fiscalyear_view.xml',

--- a/hr_period/tests/test_payslip.py
+++ b/hr_period/tests/test_payslip.py
@@ -2,6 +2,7 @@
 # Copyright 2015 Savoir-faire Linux. All Rights Reserved.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tools import mute_logger
 from . import test_hr_fiscalyear
 from odoo.exceptions import UserError, ValidationError
 
@@ -145,9 +146,10 @@ class PayslipCase(test_hr_fiscalyear.TestHrFiscalyear):
         self.payslip_obj.create(data)
         data = self._prepare_payslip_run_data(periods[0])
         run = self.run_obj.create(data)
-        with self.assertRaises(ValidationError):
-            run.write({
-                'company_id': self.company2.id})
+        with mute_logger('odoo.models'):
+            with self.assertRaises(ValidationError):
+                run.write({
+                    'company_id': self.company2.id})
         run.write({
             'hr_period_id': periods2[0].id,
             'company_id': self.company2.id})

--- a/hr_period/views/date_range_type_view.xml
+++ b/hr_period/views/date_range_type_view.xml
@@ -25,7 +25,6 @@
                     <field name="name"/>
                     <field name="allow_overlap"/>
                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
-                    <field name="parent_type_id"/>
                     <field name="hr_fiscal_year"/>
                     <field name="hr_period"/>
                     <field name="active"/>

--- a/hr_period/views/hr_payslip_run_view.xml
+++ b/hr_period/views/hr_payslip_run_view.xml
@@ -5,7 +5,7 @@
         <field name="name">hr.payslip.run.period.form</field>
         <field name="model">hr.payslip.run</field>
         <field name="inherit_id" ref="hr_payroll.hr_payslip_run_form"/>
-        <field name="priority">1</field>
+        <field name="priority">400</field>
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <label for="company_id" groups="base.group_multi_company"/>

--- a/hr_public_holidays/static/src/js/holidays_highlighter.js
+++ b/hr_public_holidays/static/src/js/holidays_highlighter.js
@@ -2,51 +2,54 @@
 // License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 odoo.define('hr_public_holidays.holidays_highlighter', function (require) {
-'use strict';
+    'use strict';
 
-var calendarView = require('web_calendar.CalendarView');
-var Model = require('web.Model');
+    var calendarView = require('web_calendar.CalendarView');
+    var Model = require('web.Model');
 
-calendarView.include({
-    willStart: function () {
-        var self = this;
+    calendarView.include({
+        willStart: function () {
+            var self = this;
 
-        var hrHolidays = new Model('hr.holidays.public.line');
-        // tasked w/ fetching desired color from server params
-        var irConfigParameter = new Model('ir.config_parameter');
+            var hrHolidays = new Model('hr.holidays.public.line');
+            // Tasked w/ fetching desired color from server params
+            var irConfigParameter = new Model('ir.config_parameter');
+            var publicHolidays = hrHolidays.call('search_read', [[], ['date']]);
+            var holidayColor = irConfigParameter.call(
+                'get_param', ['calendar.public_holidays_color']);
 
-        var publicHolidays = hrHolidays.call('search_read', [[], ['date']]);
-        var holidayColor = irConfigParameter.call(
-            'get_param', ['calendar.public_holidays_color']);
+            return $.when(publicHolidays, holidayColor, this._super())
+                .then(function () {
+                    // As a result of `search_read` call is the JS object
+                    // (dictionary), it's still our duty to clean up results
+                    self.publicHolidays = publicHolidays.map(
+                        function (holliday) {
+                            return holliday.date;
+                        });
+                    self.holidayColor = holidayColor;
+                });
+        },
+        get_fc_init_options: function () {
+            var res = this._super();
+            var self = this;
 
-        return $.when(publicHolidays, holidayColor, this._super())
-            .then(function (publicHolidays, holidayColor) {
-                // as a result of `search_read` call is the JS object
-                // (dictionary), it's still our duty to clean up results
-                self.publicHolidays = publicHolidays.map(x => x['date']);
-                self.holidayColor = holidayColor;
-            });
-    },
-    get_fc_init_options: function () {
-        var res = this._super();
-        var self = this;
+            var oldRenderHandler = res.viewRender;
+            // Extend view render callback w/ highlighting functionality
+            res.viewRender = function () {
+                // Read as super()
+                oldRenderHandler.apply(this, arguments);
+                var visibleDays = self.$('.o_calendar_view .fc-day');
+                _.each(visibleDays, function (day) {
+                    var dayDate = day.getAttribute('data-date');
+                    if (self.publicHolidays.includes(dayDate)) {
+                        // Found current day in a holiday list, colorize it
+                        day.style.backgroundColor = self.holidayColor;
+                    }
+                });
+            };
 
-        var oldRenderHandler = res['viewRender'];
-        // extend view render callback w/ highlighting functionality
-        res['viewRender'] = function (view) {
-            oldRenderHandler.apply(this, arguments);  // read as super()
-            var visibleDays = self.$('.o_calendar_view .fc-day');
-            _.each(visibleDays, function (day) {
-                var dayDate = day.getAttribute('data-date');
-                if (self.publicHolidays.includes(dayDate)) {
-                    // found current day in a holiday list, colorize it
-                    day.style.backgroundColor = self.holidayColor;
-                }
-            });
-        };
-
-        return res;
-    }
-});
+            return res;
+        },
+    });
 
 });

--- a/hr_public_holidays/tests/test_public_holidays.py
+++ b/hr_public_holidays/tests/test_public_holidays.py
@@ -5,6 +5,7 @@
 from odoo.exceptions import ValidationError
 from odoo.exceptions import Warning as UserError
 from odoo.tests import common
+from odoo.tools import mute_logger
 
 
 class TestPublicHolidays(common.TransactionCase):
@@ -64,15 +65,16 @@ class TestPublicHolidays(common.TransactionCase):
 
     def test_duplicate_year_country_fail(self):
         # ensures that duplicate year cannot be created for the same country
-        with self.assertRaises(ValidationError):
-            self.holiday_model.create({
-                'year': 1995,
-            })
-        with self.assertRaises(ValidationError):
-            self.holiday_model.create({
-                'year': 1994,
-                'country_id': self.env.ref('base.sl').id
-            })
+        with mute_logger('odoo.models'):
+            with self.assertRaises(ValidationError):
+                self.holiday_model.create({
+                    'year': 1995,
+                })
+            with self.assertRaises(ValidationError):
+                self.holiday_model.create({
+                    'year': 1994,
+                    'country_id': self.env.ref('base.sl').id
+                })
 
     def test_duplicate_date_state_fail(self):
         # ensures that duplicate date cannot be created for the same country
@@ -81,30 +83,31 @@ class TestPublicHolidays(common.TransactionCase):
             'year': 1994,
             'country_id': self.env.ref('base.us').id
         })
-        with self.assertRaises(ValidationError):
-            self.holiday_model_line.create({
-                'name': 'holiday x',
-                'date': '1994-11-14',
-                'year_id': holiday4.id
-            })
-            self.holiday_model_line.create({
-                'name': 'holiday x',
-                'date': '1994-11-14',
-                'year_id': holiday4.id
-            })
-        with self.assertRaises(ValidationError):
-            self.holiday_model_line.create({
-                'name': 'holiday x',
-                'date': '1994-11-14',
-                'year_id': holiday4.id,
-                'state_ids': [(6, 0, [self.env.ref('base.state_us_35').id])]
-            })
-            self.holiday_model_line.create({
-                'name': 'holiday x',
-                'date': '1994-11-14',
-                'year_id': holiday4.id,
-                'state_ids': [(6, 0, [self.env.ref('base.state_us_35').id])]
-            })
+        with mute_logger('odoo.models'):
+            with self.assertRaises(ValidationError):
+                self.holiday_model_line.create({
+                    'name': 'holiday x',
+                    'date': '1994-11-14',
+                    'year_id': holiday4.id
+                })
+                self.holiday_model_line.create({
+                    'name': 'holiday x',
+                    'date': '1994-11-14',
+                    'year_id': holiday4.id
+                })
+            with self.assertRaises(ValidationError):
+                self.holiday_model_line.create({
+                    'name': 'holiday x',
+                    'date': '1994-11-14',
+                    'year_id': holiday4.id,
+                    'state_ids': [(6, 0, [self.env.ref('base.state_us_35').id])]
+                })
+                self.holiday_model_line.create({
+                    'name': 'holiday x',
+                    'date': '1994-11-14',
+                    'year_id': holiday4.id,
+                    'state_ids': [(6, 0, [self.env.ref('base.state_us_35').id])]
+                })
 
     def test_isnot_holiday(self):
         # ensures that if given a date that is not an holiday it returns none

--- a/hr_public_holidays/tests/test_public_holidays.py
+++ b/hr_public_holidays/tests/test_public_holidays.py
@@ -100,13 +100,15 @@ class TestPublicHolidays(common.TransactionCase):
                     'name': 'holiday x',
                     'date': '1994-11-14',
                     'year_id': holiday4.id,
-                    'state_ids': [(6, 0, [self.env.ref('base.state_us_35').id])]
+                    'state_ids': [(6, 0,
+                                   [self.env.ref('base.state_us_35').id])]
                 })
                 self.holiday_model_line.create({
                     'name': 'holiday x',
                     'date': '1994-11-14',
                     'year_id': holiday4.id,
-                    'state_ids': [(6, 0, [self.env.ref('base.state_us_35').id])]
+                    'state_ids': [(6, 0,
+                                   [self.env.ref('base.state_us_35').id])]
                 })
 
     def test_isnot_holiday(self):

--- a/hr_recruitment_skill/__manifest__.py
+++ b/hr_recruitment_skill/__manifest__.py
@@ -5,7 +5,6 @@
 {
     'name': 'HR recruitment skill',
     'summary': 'Add skills on job position',
-    'description': 'Add required and desired skills on job position',
     'version': '10.0.1.0.0',
     'category': 'HR',
     'author': 'Camptocamp SA,Odoo Community Association (OCA)',

--- a/hr_recruitment_skill/views/hr_recruitment_skill.xml
+++ b/hr_recruitment_skill/views/hr_recruitment_skill.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-  <record id="hr_recruitment_skill.recruitment_skill_form" model="ir.ui.view">
+  <record id="recruitment_skill_form" model="ir.ui.view">
     <field name="name">hr_recruitment_skill.recruitment.skill.form</field>
     <field name="model">hr.job</field>
     <field name="inherit_id" ref="hr.view_hr_job_form"/>
@@ -15,7 +15,7 @@
     </field>
   </record>
 
-  <record id="hr_recruitment_skill.job_skill_search" model="ir.ui.view">
+  <record id="job_skill_search" model="ir.ui.view">
     <field name="name">hr.recruitment.job.skill.search</field>
     <field name="model">hr.job</field>
     <field name="inherit_id" ref="hr.view_job_filter"/>

--- a/hr_worked_days_from_timesheet/views/hr_payslip_view.xml
+++ b/hr_worked_days_from_timesheet/views/hr_payslip_view.xml
@@ -5,6 +5,7 @@
         <field name="name">hr.payslip.form</field>
         <field name="model">hr.payslip</field>
         <field name="inherit_id" ref="hr_payroll.view_hr_payslip_form"/>
+        <field name="priority">400</field>
         <field name="arch" type="xml">
             <xpath expr="//sheet/notebook/page[1]/separator[1]"
                    position="replace"/>


### PR DESCRIPTION
master branch have a lot of errors, probably changes in core addons, so in this PR I want to track, fix,   and discuss reason why they appeared 

List of errored modules
- [X] hr_holidays_validity_date
`File "/home/travis/build/OCA/hr/hr_holidays_validity_date/models/hr_holidays.py", line 52, in _check_validity_date
    tz_date_end))
UserError: (u'leaves on Legal Leaves 2019 type must be taken between 2019-03-05 18:48:42 and\n                        2019-03-06 18:48:42', '')
`
- [X] hr_public_holidays
`Exception while validating constraint
Traceback (most recent call last):
  File "/home/travis/odoo-10.0/odoo/models.py", line 1078, in _validate_fields
    check(self)
  File "/home/travis/build/OCA/hr/hr_public_holidays/models/hr_public_holidays_line.py", line 41, in _check_date_state
    r._check_date_state_one()
  File "/home/travis/build/OCA/hr/hr_public_holidays/models/hr_public_holidays_line.py", line 65, in _check_date_state_one
    'per date %s.') % self.date)
UserError: (u"You can't create duplicate public holiday per date 1994-11-14.", '')
Exception while validating constraint
Traceback (most recent call last):
  File "/home/travis/odoo-10.0/odoo/models.py", line 1078, in _validate_fields
    check(self)
  File "/home/travis/build/OCA/hr/hr_public_holidays/models/hr_public_holidays.py", line 41, in _check_year
    r._check_year_one()
  File "/home/travis/build/OCA/hr/hr_public_holidays/models/hr_public_holidays.py", line 53, in _check_year_one
    raise UserError(_('You can\'t create duplicate public holiday '
UserError: (u"You can't create duplicate public holiday per year and/or country", '')
Exception while validating constraint
Traceback (most recent call last):
  File "/home/travis/odoo-10.0/odoo/models.py", line 1078, in _validate_fields
    check(self)
  File "/home/travis/build/OCA/hr/hr_public_holidays/models/hr_public_holidays.py", line 41, in _check_year
    r._check_year_one()
  File "/home/travis/build/OCA/hr/hr_public_holidays/models/hr_public_holidays.py", line 53, in _check_year_one
    raise UserError(_('You can\'t create duplicate public holiday '
UserError: (u"You can't create duplicate public holiday per year and/or country", '')`
- [X] hr_period
`Exception while validating constraint
Traceback (most recent call last):
  File "/home/travis/odoo-10.0/odoo/models.py", line 1078, in _validate_fields
    check(self)
  File "/home/travis/build/OCA/hr/hr_period/models/hr_payslip_run.py", line 50, in _check_period_company
    "The company on the selected period must be the same "
UserError: (u'The company on the selected period must be the same as the company on the payslip batch.', '')`