### PR TITLE
[11.0][FIX/IMP] hr_employee_firstname: make required attributes dynamic

### DIFF
--- a/hr_employee_firstname/README.rst
+++ b/hr_employee_firstname/README.rst
@@ -23,7 +23,7 @@ Usage
 =====
 
 On the employee form view you will have 2 separate fields, one for Firstname,
-second for Lastname, both required.
+second for Lastname. At least one of them is required.
 
 Bug Tracker
 ===========

--- a/hr_employee_firstname/__manifest__.py
+++ b/hr_employee_firstname/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'HR Employee First Name, Last Name',
-    'version': '11.0.1.0.1',
+    'version': '11.0.1.1.0',
     'author': "Savoir-faire Linux, "
               "Fekete Mihai (Forest and Biomass Services Romania), "
               "Odoo Community Association (OCA)",

--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -1,7 +1,9 @@
-# ©  2010 - 2014 Savoir-faire Linux (<http://www.savoirfairelinux.com>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2010-2014 Savoir-faire Linux (<http://www.savoirfairelinux.com>)
+# Copyright 2016-2019 Onestein (<https://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 UPDATE_PARTNER_FIELDS = ['firstname', 'lastname', 'user_id', 'address_home_id']
 
@@ -13,39 +15,39 @@ class HrEmployee(models.Model):
     def _get_name(self, lastname, firstname):
         return self.env['res.partner']._get_computed_name(lastname, firstname)
 
-    @api.multi
     @api.onchange('firstname', 'lastname')
-    def get_name(self):
-        for employee in self:
-            if employee.firstname and employee.lastname:
-                employee.name = self._get_name(
-                    employee.lastname, employee.firstname)
+    def _onchange_firstname_lastname(self):
+        if self.firstname or self.lastname:
+            self.name = self._get_name(self.lastname, self.firstname)
 
-    def _firstname_default(self):
-        return ' ' if self.env.context.get('module') else False
-
-    firstname = fields.Char(
-        "Firstname", default=_firstname_default)
-    lastname = fields.Char(
-        "Lastname", required=True, default=_firstname_default)
+    firstname = fields.Char()
+    lastname = fields.Char()
 
     @api.model
     def create(self, vals):
-        if vals.get('firstname') and vals.get('lastname'):
-            vals['name'] = self._get_name(vals['lastname'], vals['firstname'])
-
+        if vals.get('firstname') or vals.get('lastname'):
+            vals['name'] = self._get_name(
+                vals.get('lastname'), vals.get('firstname'))
         elif vals.get('name'):
             vals['lastname'] = self.split_name(vals['name'])['lastname']
             vals['firstname'] = self.split_name(vals['name'])['firstname']
+        else:
+            raise ValidationError(_('No name set.'))
         res = super(HrEmployee, self).create(vals)
         self._update_partner_firstname(res)
         return res
 
     @api.multi
     def write(self, vals):
-        if vals.get('firstname') or vals.get('lastname'):
-            lastname = vals.get('lastname') or self.lastname or ' '
-            firstname = vals.get('firstname') or self.firstname or ' '
+        if 'firstname' in vals or 'lastname' in vals:
+            if 'lastname' in vals:
+                lastname = vals.get('lastname')
+            else:
+                lastname = self.lastname
+            if 'firstname' in vals:
+                firstname = vals.get('firstname')
+            else:
+                firstname = self.firstname
             vals['name'] = self._get_name(lastname, firstname)
         elif vals.get('name'):
             vals['lastname'] = self.split_name(vals['name'])['lastname']
@@ -63,7 +65,7 @@ class HrEmployee(models.Model):
     @api.model
     def _update_employee_names(self):
         employees = self.search([
-            ('firstname', '=', ' '), ('lastname', '=', ' ')])
+            ('firstname', '=', False), ('lastname', '=', False)])
 
         for ee in employees:
             split_name = self.split_name(ee.name)
@@ -80,3 +82,10 @@ class HrEmployee(models.Model):
                 partners += partner
         partners.write({'firstname': employee.firstname,
                         'lastname': employee.lastname})
+
+    @api.constrains("firstname", "lastname")
+    def _check_name(self):
+        """Ensure at least one name is set."""
+        for record in self:
+            if not (record.firstname or record.lastname or record.name):
+                raise ValidationError(_('No name set.'))

--- a/hr_employee_firstname/tests/test_hr_employee_firstname.py
+++ b/hr_employee_firstname/tests/test_hr_employee_firstname.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2014 Savoir-faire Linux. All Rights Reserved.
+# Copyright 2016-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import odoo
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -121,3 +123,10 @@ class TestEmployeeFirstname(TransactionCase):
 
         self.assertEqual(self.empl_demo.firstname, 'Parker')
         self.assertEqual(self.empl_demo.lastname, 'Pieter')
+
+    def test_no_name(self):
+        self.employee_model.create({'firstname': 'test'})
+        self.employee_model.create({'lastname': 'test'})
+        self.employee_model.create({'name': 'test'})
+        with self.assertRaises(ValidationError):
+            self.employee_model.create({})

--- a/hr_employee_firstname/views/hr_view.xml
+++ b/hr_employee_firstname/views/hr_view.xml
@@ -9,19 +9,15 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="readonly">1</attribute>
                 <attribute name="no_label">1</attribute>
                 <attribute name="required">0</attribute>
             </xpath>
-            <xpath expr="//field[@name='name']" position="after">
-                <label for="firstname" class="oe_edit_only"/>
-                <h1>
-                    <field name="firstname"/>
-                 </h1>
-                <label for="lastname" class="oe_edit_only"/>
-                <h1>
-                    <field name="lastname"/>
-                 </h1>
+            <xpath expr="//h1//field[@name='name']/.." position="after">
+                <group>
+                    <field name="firstname" attrs="{'required': [('lastname', '=', False)]}"/>
+                    <field name="lastname" attrs="{'required': [('firstname', '=', False)]}"/>
+                </group>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Fixes https://github.com/OCA/hr/issues/580

This PR is the backport of the latest fixes made in https://github.com/OCA/hr/pull/577 for V12:

- Makes required attribute dynamic, like it was already done in `partner_firstname`, so that one of the the two "_firstname_ or _lastname_" is required.
- Fixes the create method, see https://github.com/OCA/hr/issues/580
- Fixes the write method
- Fixes the onchange method (`self.firstname `**`or`**` self.lastname`)
