### PR TITLE
[FIX] hr_holidays_public: Traceback when change the date was fixed

### DIFF
--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -191,3 +191,14 @@ class HrHolidaysPublicLine(models.Model):
             raise UserError(_('You can\'t create duplicate public holiday '
                               'per date %s.') % self.date)
         return True
+
+    @api.onchange('date')
+    def onchange_date(self):
+        if not self.variable_date:
+            self.date = False
+            return {'warning': {
+                'title': _('WARNING'),
+                'message': _(
+                    'The check that does not allow change the date is '
+                    'enabled, the date cannot be changed for this line.'),
+            }}

--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -199,6 +199,6 @@ class HrHolidaysPublicLine(models.Model):
             return {'warning': {
                 'title': _('WARNING'),
                 'message': _(
-                    'The check that does not allow change the date is '
+                    'The check that does not allow to change the date is '
                     'enabled, the date cannot be changed for this line.'),
             }}

--- a/hr_holidays_public/views/hr_holidays_public_view.xml
+++ b/hr_holidays_public/views/hr_holidays_public_view.xml
@@ -30,7 +30,7 @@
                     <field name="line_ids" nolabel="1">
                         <tree string="Public Holidays"
                             editable="top">
-                            <field name="date" attrs="{'readonly':[['variable_date', '=', False]]}" />
+                            <field name="date"/>
                             <field name="name" />
                             <field name="state_ids" widget="many2many_tags"
                                 domain="[('country_id','=',parent.country_id)]" />


### PR DESCRIPTION
The field date in the public holidays cannot be changed when the field
to block the field cancellation is True.

With the attrs to block the field, if the record is not saved, the date
field is clear and do not allow to save the record because is a required
field. Then was improved with the onchange, to show an error message if
the date is changed and the check to block is True.

[Closes](https://github.com/OCA/hr/issues/569)