### PR TITLE
[10.0][FIX/IMP] hr_employee_firstname: make required attributes dynamic

### DIFF
--- a/hr_employee_firstname/__manifest__.py
+++ b/hr_employee_firstname/__manifest__.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 # ©  2010 - 2014 Savoir-faire Linux (<http://www.savoirfairelinux.com>)
+# Copyright 2016-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': 'HR Employee First Name, Last Name',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'author': "Savoir-faire Linux, "
               "Fekete Mihai (Forest and Biomass Services Romania), "
+              "Onestein, "
               "Odoo Community Association (OCA)",
     'maintainer': 'Savoir-faire Linux',
-    'website': 'http://www.savoirfairelinux.com',
+    'website': 'https://github.com/OCA/hr/',
     'license': 'AGPL-3',
     'category': 'Human Resources',
     'summary': 'Adds First Name to Employee',

--- a/hr_employee_firstname/init_hook.py
+++ b/hr_employee_firstname/init_hook.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 Onestein (<http://www.onestein.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2016-2019 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import SUPERUSER_ID
 from odoo.api import Environment
@@ -8,4 +8,4 @@ from odoo.api import Environment
 
 def post_init_hook(cr, pool):
     env = Environment(cr, SUPERUSER_ID, {})
-    env['hr.employee']._update_employee_names()
+    env['hr.employee']._install_employee_firstname()

--- a/hr_employee_firstname/views/hr_view.xml
+++ b/hr_employee_firstname/views/hr_view.xml
@@ -6,22 +6,19 @@
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="priority">400</field>
         <field name="arch" type="xml">
-            <xpath expr="//label[@for='name']" position="replace">
-                <label for="firstname" class="oe_edit_only"/>
+            <xpath expr="//label[@for='name']" position="attributes">
+                <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="readonly">1</attribute>
                 <attribute name="no_label">1</attribute>
                 <attribute name="required">0</attribute>
             </xpath>
-            <xpath expr="//field[@name='name']" position="after">
-                 <field name="firstname"/>
-            </xpath>
-            <xpath expr="//field[@name='name']/.." position="after">
-                <label for="lastname" class="oe_edit_only"/>
-                <h1>
-                    <field name="lastname"/>
-                 </h1>
+            <xpath expr="//h1//field[@name='name']/.." position="after">
+                <group>
+                    <field name="firstname" attrs="{'required': [('lastname', '=', False)]}"/>
+                    <field name="lastname" attrs="{'required': [('firstname', '=', False)]}"/>
+                </group>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Fixes #580

This PR is the backport of the latest fixes made in #583 for V11:

- Makes required attribute dynamic, so that one of the the two "firstname or lastname" is required.
- Fixes the create method, see #580
- Fixes the write method
- Fixes the onchange method (self.firstname or self.lastname)
