### PR TITLE
[IMP] holidays_public: Return Intervals with holiday lines

### DIFF
--- a/hr_holidays_public/__manifest__.py
+++ b/hr_holidays_public/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'HR Holidays Public',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'license': 'AGPL-3',
     'category': 'Human Resources',
     'author': "Michael Telahun Makonnen, "

--- a/hr_holidays_public/models/resource.py
+++ b/hr_holidays_public/models/resource.py
@@ -26,8 +26,11 @@ class ResourceCalendar(models.Model):
             for line in lines:
                 date = fields.Datetime.from_string(line.date)
                 leaves.append(
-                    (datetime.datetime.combine(date, datetime.time.min),
-                     datetime.datetime.combine(date, datetime.time.max)),
+                    self._interval_new(
+                        datetime.datetime.combine(date, datetime.time.min),
+                        datetime.datetime.combine(date, datetime.time.max),
+                        {'holidays': line}
+                    ),
                 )
         return leaves
 


### PR DESCRIPTION
With this change, the leaves are Intervals with holidays as data. Now it can be detected the origin when processing it.
It might be interesting if a working interval should be affected by leaves but not by public holidays. like people that works on holidays (policeman, doctors, firemans ...)