### PR TITLE
[FIX] Added general permission on hr_employee_skill and fixed service_duration error, field does not exist on view

### DIFF
--- a/hr_employee_service/views/hr_employee.xml
+++ b/hr_employee_service/views/hr_employee.xml
@@ -17,7 +17,7 @@
                     <field name="service_termination_date"/>
 
                     <field name="service_duration" invisible="1"/>
-                    <label for="service_duration"/>
+                    <label for="service_duration" string="Service Duration"/>
                     <div>
                         <field name="service_duration_years" nolabel="1"/>
                         <span class="ml8 mr8" >year(s)</span>

--- a/hr_experience/views/hr_employee_view.xml
+++ b/hr_experience/views/hr_employee_view.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="arch" type="xml">
             <notebook position="inside">
-                <page string="Resume" groups="base.group_user">
+                <page string="Resume" name="resume" groups="hr.group_hr_user">
                     <group string="Academic Experiences">
                         <field name="academic_ids" context="{'default_employee_id': active_id}" nolabel="1">
                             <tree string="Academic Experiences">

--- a/hr_skill/security/ir.model.access.csv
+++ b/hr_skill/security/ir.model.access.csv
@@ -2,3 +2,4 @@
 "access_hr_skill","hr.skill","model_hr_skill","base.group_user",1,0,0,0
 "access_hr_skill_manager","hr.skill","model_hr_skill","hr.group_hr_manager",1,1,1,1
 "access_employee_skill_user","hr.employee.skill","model_hr_employee_skill","hr.group_hr_user",1,1,1,1
+"access_employee_skill","hr.employee.skill","model_hr_employee_skill","base.group_user",1,0,0,0

--- a/hr_skill/views/hr_employee.xml
+++ b/hr_skill/views/hr_employee.xml
@@ -12,7 +12,7 @@
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="arch" type="xml">
             <notebook position="inside">
-                <page string="Skills">
+                <page string="Skills" name="employee_skills" groups="hr.group_hr_user">
                     <group>
                         <field name="employee_skill_ids" nolabel="1">
                             <tree editable="bottom">


### PR DESCRIPTION
When the logged user only has the field type_user configured as internal type, the employee form can not be opened because does not find the field service_duration on view.