### PR TITLE
[FIX] hr_expense: Allow a user to attach an invoice in draft

### DIFF
--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -11,7 +11,7 @@ class HrExpense(models.Model):
     invoice_id = fields.Many2one(
         comodel_name='account.invoice',
         string='Vendor Bill',
-        domain="[('type', '=', 'in_invoice'), ('state', '=', 'open')]",
+        domain="[('type', '=', 'in_invoice'), ('state', 'in', ('draft', 'open'))]",
         oldname='invoice',
     )
 


### PR DESCRIPTION
If the accounting team is the one in charge of validating invoices (users can't validate), then the users won't be able to attach invoices made by them from the expense app.

This also fixes a weird behavior as you can can hit the create and edit button; complete the invoice and save it; but then it won't be shown in the selection, but you can't neither search it.