### PR TITLE
[12.0][ADD] Migration script from hr_employee_seniority

### DIFF
--- a/hr_employee_service_contract/migrations/12.0.1.0.0/pre-migration.py
+++ b/hr_employee_service_contract/migrations/12.0.1.0.0/pre-migration.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Eficent <http://www.eficent.com>
+# Copyright 2019 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cr = env.cr
+    if openupgrade.column_exists(cr, 'hr_employee', 'initial_employment_date'):
+        openupgrade.logged_query(
+            cr, """
+            UPDATE hr_employee
+            SET service_hire_date = initial_employment_date;
+            WHERE initial_employment_date IS NOT NULL;
+            """
+        )


### PR DESCRIPTION
In 12.0 exists a module named `hr_employee_service_contract` that has very similar functionality than this. 
After the discussion in #606 it was decided than instead of migrating `hr_employee_seniority` we would add a migration script on `hr_employee_service_contract` to transform the old module onto the new one.
It transforms the field `initial_employment_date` to `service_hire_date`. I am not sure if this is the best solution since that field probably should become `service_start_date` if it was not a related field.
