### PR TITLE
[12.0][IMP] hr_holidays_public: Create global calendar.event

### DIFF
--- a/hr_holidays_public/README.rst
+++ b/hr_holidays_public/README.rst
@@ -74,6 +74,15 @@ This may or may not be a problem, yet since this component is also being set to
 `resource.calendar.attendance` records in `_attendance_intervals()`, seems it
 should be ok.
 
+There are no restrictions to block users from modifying or removing calendar
+events linked to public holidays. There's a suggestion to overload `write` and
+`unlink` methods of `calendar.event`, but it might have other impacts like
+users not being able to edit event tags, or even custom fields.
+
+Regional public holidays are shown in the public calendar. The regions will be
+noted in the description of the event, but it'll be shown to all users. It'd
+be good to have it show only for users in these regions.
+
 Bug Tracker
 ===========
 
@@ -93,6 +102,7 @@ Authors
 * Michael Telahun Makonnen
 * Tecnativa
 * Fekete Mihai (Forest and Biomass Services Romania)
+* Druidoo
 
 Contributors
 ~~~~~~~~~~~~
@@ -111,6 +121,10 @@ Contributors
 * `Brainbean Apps <https://brainbeanapps.com>`__:
 
   * Alexey Pelykh <alexey.pelykh@brainbeanapps.com>
+
+* `Druidoo <https://www.druidoo.io>`__:
+
+  * Iván Todorovich <ivan.todorovich@druidoo.io>
 
 Maintainers
 ~~~~~~~~~~~

--- a/hr_holidays_public/__manifest__.py
+++ b/hr_holidays_public/__manifest__.py
@@ -9,6 +9,7 @@
     'author': "Michael Telahun Makonnen, "
               "Tecnativa, "
               "Fekete Mihai (Forest and Biomass Services Romania),"
+              "Druidoo, "
               "Odoo Community Association (OCA)",
     'summary': "Manage Public Holidays",
     'website': 'https://github.com/OCA/hr',
@@ -16,6 +17,7 @@
         'hr_holidays',
     ],
     'data': [
+        'data/data.xml',
         'security/ir.model.access.csv',
         'views/hr_holidays_public_view.xml',
         'views/hr_leave_type.xml',

--- a/hr_holidays_public/data/data.xml
+++ b/hr_holidays_public/data/data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="event_type_holiday" model="calendar.event.type">
+        <field name="name">Holidays</field>
+    </record>
+
+</odoo>

--- a/hr_holidays_public/migrations/12.0.2.0.0/post-migration.py
+++ b/hr_holidays_public/migrations/12.0.2.0.0/post-migration.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Druidoo - Iván Todorovich <ivan.todorovich@druidoo.io>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, SUPERUSER_ID
+
+import logging
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        holidays_without_meeting = env['hr.holidays.public.line'].search([
+            ('meeting_id', '=', False)])
+        for holiday in holidays_without_meeting:
+            _logger.debug('Creating meeting for holiday: %s' % holiday.name)
+            holiday.meeting_id = env['calendar.event'].create(
+                holiday._prepare_holidays_meeting_values())

--- a/hr_holidays_public/readme/CONTRIBUTORS.rst
+++ b/hr_holidays_public/readme/CONTRIBUTORS.rst
@@ -12,3 +12,7 @@
 * `Brainbean Apps <https://brainbeanapps.com>`__:
 
   * Alexey Pelykh <alexey.pelykh@brainbeanapps.com>
+
+* `Druidoo <https://www.druidoo.io>`__:
+
+  * Iván Todorovich <ivan.todorovich@druidoo.io>

--- a/hr_holidays_public/readme/ROADMAP.rst
+++ b/hr_holidays_public/readme/ROADMAP.rst
@@ -5,3 +5,12 @@ setting third component of a tuple to a `hr.holidays.public.line` record.
 This may or may not be a problem, yet since this component is also being set to
 `resource.calendar.attendance` records in `_attendance_intervals()`, seems it
 should be ok.
+
+There are no restrictions to block users from modifying or removing calendar
+events linked to public holidays. There's a suggestion to overload `write` and
+`unlink` methods of `calendar.event`, but it might have other impacts like
+users not being able to edit event tags, or even custom fields.
+
+Regional public holidays are shown in the public calendar. The regions will be
+noted in the description of the event, but it'll be shown to all users. It'd
+be good to have it show only for users in these regions.

--- a/hr_holidays_public/static/description/index.html
+++ b/hr_holidays_public/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.14: http://docutils.sourceforge.net/" />
 <title>HR Holidays Public</title>
 <style type="text/css">
 
@@ -423,6 +423,13 @@ setting third component of a tuple to a <cite>hr.holidays.public.line</cite> rec
 This may or may not be a problem, yet since this component is also being set to
 <cite>resource.calendar.attendance</cite> records in <cite>_attendance_intervals()</cite>, seems it
 should be ok.</p>
+<p>There are no restrictions to block users from modifying or removing calendar
+events linked to public holidays. There’s a suggestion to overload <cite>write</cite> and
+<cite>unlink</cite> methods of <cite>calendar.event</cite>, but it might have other impacts like
+users not being able to edit event tags, or even custom fields.</p>
+<p>Regional public holidays are shown in the public calendar. The regions will be
+noted in the description of the event, but it’ll be shown to all users. It’d
+be good to have it show only for users in these regions.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
@@ -440,6 +447,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Michael Telahun Makonnen</li>
 <li>Tecnativa</li>
 <li>Fekete Mihai (Forest and Biomass Services Romania)</li>
+<li>Druidoo</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -458,6 +466,10 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://brainbeanapps.com">Brainbean Apps</a>:<ul>
 <li>Alexey Pelykh &lt;<a class="reference external" href="mailto:alexey.pelykh&#64;brainbeanapps.com">alexey.pelykh&#64;brainbeanapps.com</a>&gt;</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.druidoo.io">Druidoo</a>:<ul>
+<li>Iván Todorovich &lt;<a class="reference external" href="mailto:ivan.todorovich&#64;druidoo.io">ivan.todorovich&#64;druidoo.io</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/hr_holidays_public/tests/test_holidays_public.py
+++ b/hr_holidays_public/tests/test_holidays_public.py
@@ -218,3 +218,18 @@ class TestHolidaysPublic(TransactionCase):
 
         with self.assertRaises(UserError):
             wz_create_ph.create_public_holidays()
+
+    def test_calendar_event_created(self):
+        holiday = self.holiday_model.create({
+            'year': 2019,
+            'country_id': self.env.ref('base.us').id
+        })
+        hline = self.holiday_model_line.create({
+            'name': 'holiday x',
+            'date': '2019-07-30',
+            'year_id': holiday.id
+        })
+        meeting_id = hline.meeting_id
+        self.assertTrue(meeting_id)
+        hline.unlink()
+        self.assertFalse(meeting_id.exists())


### PR DESCRIPTION
Notice there are 2 commits:

- The first one is just making the code a little bit more readable. No big changes there, but many lines are affected.

- The second one is the actual IMP

With this PR, public holidays will create events on the global calendar.
This is aligned with Odoo's creation of calendar events for hr.leaves, when validated.

Note that:
- The name of the event will be the name of the holiday.
- There's a "Holidays" tag applied to the event.
- The event will appear under the global calendar (Everybody's calendars)
- Since the event is created by the system, the user responsible is 'OdooBot' (System user)
- The event will be updated if the public holiday is updated
- The event will be deleted if the public holiday is deleted


![image](https://user-images.githubusercontent.com/1914185/62135799-259edf80-b2e3-11e9-8cc1-881e09255d33.png)

Maybe a known issue would be that users can edit the calendar event and the changes will not be blocked nor synced to the public holiday. I didn't want to get into this because that's the same behaviour we have with the events created for hr.leaves.