### PR TITLE
[12.0][FIX] hr_holidays_notify_employee_manager: Add readonly False o…

### DIFF
--- a/hr_holidays_notify_employee_manager/models/res_config_settings.py
+++ b/hr_holidays_notify_employee_manager/models/res_config_settings.py
@@ -8,7 +8,7 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     leave_notify_manager = fields.Boolean(
-        related='company_id.leave_notify_manager',
+        related='company_id.leave_notify_manager', readonly=False,
         string="Leave Requests notified to employee's manager",
         help="When a leave request is created the employee's manager "
              "will be added as follower and notified by email.")


### PR DESCRIPTION
…n leave_notify_manager option.

We must specify readonly=False on Transient Model fields to be editable.

CC @Nikul-Chaudhary @mreficent 