### PR TITLE
[12.0][IMP] Add migration script hr_family -> hr_employee_relative

### DIFF
--- a/hr_employee_relative/migrations/12.0.1.0.0/post-migration.py
+++ b/hr_employee_relative/migrations/12.0.1.0.0/post-migration.py
@@ -19,6 +19,8 @@ def migrate(env, version):
         if employee[1] or employee[2] or employee[3]:
             env['hr.employee.relative'].create({
                 'employee_id': employee[0],
+                'job': employee[2],
+                'phone_number': employee[3],
                 'name': employee[1] or 'Spouse',
                 'relation_id': relation_spouse
             })

--- a/hr_employee_relative/migrations/12.0.1.0.0/post-migration.py
+++ b/hr_employee_relative/migrations/12.0.1.0.0/post-migration.py
@@ -1,0 +1,50 @@
+# Copyright 2019 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cr = env.cr
+    columns = 'fam_spouse, fam_spouse_employer, fam_spouse_tel, fam_father,' \
+              ' fam_father_date_of_birth, fam_mother, fam_mother_date_of_birth'
+    cr.execute('SELECT id, %s FROM hr_employee' % columns)
+
+    relation_spouse = env.ref('hr_employee_relative.relation_spouse').id
+    relation_parent = env.ref('hr_employee_relative.relation_parent').id
+    relation_child = env.ref('hr_employee_relative.relation_child').id
+
+    for employee in cr.fetchall():
+        if employee[1] or employee[2] or employee[3]:
+            env['hr.employee.relative'].create({
+                'employee_id': employee[0],
+                'name': employee[1] or 'Spouse',
+                'relation_id': relation_spouse
+            })
+        if employee[4] or employee[5]:
+            env['hr.employee.relative'].create({
+                'employee_id': employee[0],
+                'name': employee[4] or 'Father',
+                'date_of_birth': employee[5] or False,
+                'relation_id': relation_parent
+            })
+        if employee[6] or employee[7]:
+            env['hr.employee.relative'].create({
+                'employee_id': employee[0],
+                'name': employee[6] or 'Mother',
+                'date_of_birth': employee[7] or False,
+                'relation_id': relation_parent
+            })
+    cr.execute(
+        'SELECT name, date_of_birth, employee_id, gender'
+        ' FROM hr_employee_children'
+    )
+    for children in cr.fetchall():
+        env['hr.employee.relative'].create({
+            'name': children[0] or 'Child',
+            'date_of_birth': children[1] or False,
+            'employee_id': children[2],
+            'gender': children[3] or False,
+            'relation_id': relation_child
+        })

--- a/hr_employee_relative/models/hr_employee_relative.py
+++ b/hr_employee_relative/models/hr_employee_relative.py
@@ -45,6 +45,10 @@ class HrEmployeeRelative(models.Model):
     age = fields.Float(
         compute='_compute_age',
     )
+
+    job = fields.Char()
+    phone_number = fields.Char()
+
     notes = fields.Text(
         string='Notes',
     )

--- a/hr_employee_relative/views/hr_employee_relative.xml
+++ b/hr_employee_relative/views/hr_employee_relative.xml
@@ -16,6 +16,8 @@
                 <field name="gender"/>
                 <field name="date_of_birth"/>
                 <field name="age" readonly="1"/>
+                <field name="phone_number"/>
+                <field name="job"/>
                 <field name="notes"/>
             </tree>
         </field>


### PR DESCRIPTION
Added migration script hr_family -> hr_employee_relative. Related to discussion in https://github.com/OCA/hr/pull/487

I have tested it a couple of times and looks like its working properly, still there are a couple of things to discuss.
- Should we drop the old columns and tables or keep them for security?
- The fields `fam_spouse_employer` and `fam_spouse_tel` which represent the job of the spouse and the phone number dont exist in `hr_employee_relative`. Should we add them?

(PR in OpenUpgrade https://github.com/OCA/OpenUpgrade/pull/1995)