### PR TITLE
[12.0][FIX] hr_employee_service: Test 3

### DIFF
--- a/hr_employee_service/tests/test_hr_employee_service.py
+++ b/hr_employee_service/tests/test_hr_employee_service.py
@@ -5,6 +5,8 @@ from odoo import fields
 from odoo.tests import common
 
 from dateutil.relativedelta import relativedelta
+from datetime import date
+from mock import patch
 
 
 class TestHrEmployeeService(common.TransactionCase):
@@ -51,19 +53,22 @@ class TestHrEmployeeService(common.TransactionCase):
         self.assertEqual(employee.service_duration_days, 0)
 
     def test_3(self):
+        mocked_today = date(2019, 8, 27)
         employee = self.SudoEmployee.create({
             'name': 'Employee #3',
             'service_hire_date': (
-                self.today - relativedelta(months=6)
+                mocked_today - relativedelta(months=6)
             ),
             'service_start_date': (
-                self.today - relativedelta(months=6)
+                mocked_today - relativedelta(months=6)
             ),
         })
 
-        self.assertEqual(employee.service_duration_years, 0)
-        self.assertEqual(employee.service_duration_months, 6)
-        self.assertEqual(employee.service_duration_days, 0)
+        with patch('odoo.fields.Date.today') as today:
+            today.return_value = mocked_today
+            self.assertEqual(employee.service_duration_years, 0)
+            self.assertEqual(employee.service_duration_months, 6)
+            self.assertEqual(employee.service_duration_days, 0)
 
     def test_4(self):
         employee = self.SudoEmployee.create({


### PR DESCRIPTION
Test 3 created an employee with a hire date 6 months previous than today and then tested that the computation was correct and the employee had a length of service of exactly 6 months.
Today it is `2019-08-29` and 6 months ago it should be `2019-02-29` but since it was February, python's `relativedelta` returns `2019-02-28` which makes the length of service 6 months and 1 day long, which made the test fail.
I know this only happens once a year and tomorrow tests will work properly but I this this little fix is good to have anyways.