### PR TITLE
[11.0][FIX] hr_expense_invoice: Expense validation error due to a floating point error

### DIFF
--- a/hr_expense_invoice/README.rst
+++ b/hr_expense_invoice/README.rst
@@ -74,6 +74,10 @@ Contributors
   * Pedro M. Baeza
   * Vicent Cubells
 
+* `NuoBiT Solutions, S.L. <https://www.nuobit.com>`_:
+
+  * Eric Antones
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -25,7 +25,8 @@ class HrExpenseSheet(models.Model):
             c_move_lines = move_lines.filtered(
                 lambda x:
                 x.partner_id == partner and
-                x.debit == line.invoice_id.residual and
+                float_compare(x.debit, line.invoice_id.residual,
+                              precision) == 0 and
                 not x.reconciled
             )
             if len(c_move_lines) > 1:


### PR DESCRIPTION
Some invoice-type expenses are not found because the filter parameters are not being rounded