### PR TITLE
[11.0][IMP] hr_attendance_report_theoretical_time: Add filter wizard

### DIFF
--- a/hr_attendance_report_theoretical_time/__init__.py
+++ b/hr_attendance_report_theoretical_time/__init__.py
@@ -2,3 +2,4 @@
 
 from . import models
 from . import reports
+from . import wizards

--- a/hr_attendance_report_theoretical_time/__manifest__.py
+++ b/hr_attendance_report_theoretical_time/__manifest__.py
@@ -20,5 +20,6 @@
         "views/hr_leave_type_views.xml",
         "views/hr_employee_views.xml",
         "reports/hr_attendance_theoretical_time_report_views.xml",
+        "wizards/wizard_theoretical_time.xml",
     ],
 }

--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
@@ -65,10 +65,17 @@
               action="hr_attendance.hr_attendance_action_graph"
     />
 
-    <menuitem id="menu_hr_attendance_theoretical_report"
+    <menuitem id="menu_hr_attendance_theoretical_root"
               name="Theoretical vs Attended Time"
-              action="hr_attendance_theoretical_action"
               parent="hr_attendance.menu_hr_attendance_report"
+              sequence="15"
+              groups="hr_attendance.group_hr_attendance_user"
+    />
+
+    <menuitem id="menu_hr_attendance_theoretical_report"
+              name="All Employees"
+              action="hr_attendance_theoretical_action"
+              parent="menu_hr_attendance_theoretical_root"
               groups="hr_attendance.group_hr_attendance"
               sequence="20"
     />

--- a/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
@@ -195,3 +195,23 @@ class TestHrAttendanceReportTheoreticalTime(common.SavepointCase):
         # 1946-12-26 - Employee 1
         a = self.attendances[6]
         self.assertEqual(obj._theoretical_hours(a.employee_id, a.check_in), 8)
+
+    def test_wizard_theoretical_time(self):
+        department = self.env['hr.department'].create({'name': 'Department'})
+        tag = self.env['hr.employee.category'].create({'name': 'Tag'})
+        self.employee_1.write({
+            'department_id': department.id,
+            'category_ids': [(4, tag.id)],
+        })
+        wizard = self.env['wizard.theoretical.time'].create({
+            'department_id': department.id,
+            'category_ids': [(4, tag.id)],
+        })
+        wizard.populate()
+        report = wizard.view_report()
+        self.assertTrue(wizard.employee_ids)
+        self.assertEqual(wizard.employee_ids[0].name, self.employee_1.name)
+        self.assertEqual(
+            report['domain'],
+            [('employee_id', 'in', [self.employee_1.id])]
+        )

--- a/hr_attendance_report_theoretical_time/wizards/__init__.py
+++ b/hr_attendance_report_theoretical_time/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard_theoretical_time

--- a/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
@@ -1,0 +1,62 @@
+# Copyright 2019 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, _
+
+
+class WizardTheoreticalTime(models.TransientModel):
+
+    _name = 'wizard.theoretical.time'
+
+    employee_ids = fields.Many2many('hr.employee', string='Employees')
+
+    department_id = fields.Many2one(
+        'hr.department', string='Department'
+    )
+    category_ids = fields.Many2many(
+        'hr.employee.category', string='Tag'
+    )
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if self.env.user.employee_ids:
+            res[
+                'department_id'
+            ] = self.env.user.employee_ids[0].department_id.id
+        return res
+
+    def _prepare_employee_domain(self):
+        res = []
+        if self.category_ids:
+            res.append(('category_ids', 'in', self.category_ids.ids))
+        if self.department_id:
+            res.append(('department_id', 'child_of', self.department_id.id))
+        return res
+
+    @api.multi
+    def populate(self):
+        domain = self._prepare_employee_domain()
+        self.employee_ids = self.env['hr.employee'].search(domain)
+        action = {
+            'name': _('Select Employees to Analyze Theoretical Time'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'wizard.theoretical.time',
+            'view_mode': 'form',
+            'target': 'new',
+            'res_id': self.id,
+            'context': self._context,
+        }
+        return action
+
+    @api.multi
+    def view_report(self):
+        self.ensure_one()
+        action = {
+            'type': 'ir.actions.act_window',
+            'name': 'Theoretical vs Attended Time Analysis',
+            'res_model': 'hr.attendance.theoretical.time.report',
+            'domain': [('employee_id', 'in', self.employee_ids.ids)],
+            'view_mode': 'pivot,graph',
+        }
+        return action

--- a/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.xml
+++ b/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Creu Blanca
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="wizard_theoretical_time_form_view">
+        <field name="name">wizard.theoretical.time.form (in hr_attendance_report_theoretical_time)</field>
+        <field name="model">wizard.theoretical.time</field>
+        <field name="arch" type="xml">
+            <form string="Wizard Theoretical Time">
+                <group string="Filters">
+                    <group>
+                        <field name="department_id" options="{'no_open': True, 'no_create': True}"/>
+                    </group>
+                    <group>
+                        <field name="category_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_open': True, 'no_create': True}"/>
+                    </group>
+                </group>
+                <div class="text-left">
+                   <button name="populate" string="Populate" type="object" class="btn-primary"/>
+                </div>
+                <notebook>
+                    <page string="Employees">
+                        <field name="employee_ids">
+                            <tree delete="1" editable="0">
+                                <field name="name" readonly="1"/>
+                                <field name="department_id" readonly="1"/>
+                                <field name="job_id" readonly="1"/>
+                                <field name="parent_id" readonly="1"/>
+                            </tree>
+                        </field>
+                    </page>
+                </notebook>
+                <footer>
+                    <button name="view_report" string="View Report" class="btn-primary" type="object"/>
+                    <button string="Cancel" class="btn-default" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="wizard_theoretical_time_act_window">
+        <field name="name">Select Employees to Analyze Theoretical Time</field>
+        <field name="res_model">wizard.theoretical.time</field>
+        <field name="view_mode">form</field>
+        <field name="context">{}</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_hr_attendance_theoretical_report_select"
+              name="Select Employees"
+              action="wizard_theoretical_time_act_window"
+              parent="menu_hr_attendance_theoretical_root"
+              groups="hr_attendance.group_hr_attendance"
+              sequence="25"
+    />
+
+</odoo>


### PR DESCRIPTION
The attended vs theoretical time report takes a lot of time in databases with a lot of employees, which is completely normal, but sometimes if you just want to check the analysis of a specific group of employees it can be a waste of time waiting for the computation of all employees.
This wizard allows you to select for which employees you want to get the analysis before computing all of them.
![imagen](https://user-images.githubusercontent.com/47532076/65024725-b2eecf80-d935-11e9-901f-44745420a530.png)
