### PR TITLE
FIX: fix leave number days when requested across years and public holidays are defined for each year

### DIFF
--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -26,6 +26,17 @@ class ResourceCalendar(models.Model):
         HrHolidaysPublic = self.env['hr.holidays.public']
 
         leaves = []
+        if start_dt.year != end_dt.year:
+            # This fixes the case of leave request asked over 2 years.
+            #
+            # adding 1 year to end_dt for rrule to retrieve correct years for
+            # public holidays to work
+            # rrule.rrule(rrule.YEARLY, dtstart=2019-12-22, until=2020-01-05)
+            # gives [2019]
+            # rrule.rrule(rrule.YEARLY, dtstart=2019-12-22, until=2021-01-05)
+            # gives [2019, 2020]
+            end_dt = end_dt.replace(year=end_dt.year+1)
+
         for day in rrule.rrule(rrule.YEARLY, dtstart=start_dt, until=end_dt):
             lines = HrHolidaysPublic.get_holidays_list(
                 day.year, employee_id=employee_id,

--- a/hr_holidays_public/tests/test_holidays_calculation.py
+++ b/hr_holidays_public/tests/test_holidays_calculation.py
@@ -84,6 +84,20 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
             ],
         })
 
+        cls.public_holiday_global_1947 = cls.HrHolidaysPublic.create({
+            'year': 1947,
+            'line_ids': [
+                (0, 0, {
+                    'name': 'New Eve',
+                    'date': '1947-01-01',
+                }),
+                (0, 0, {
+                    'name': 'New Eve extended',
+                    'date': '1947-01-02',
+                }),
+            ],
+        })
+
         cls.holiday_type = cls.HrLeaveType.create({
             'name': 'Leave Type Test',
             'exclude_public_holidays': True,
@@ -121,6 +135,26 @@ class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
             'date_to': '1946-12-29 23:59:59',  # Sunday
             'holiday_status_id': self.holiday_type_no_excludes.id,
             'employee_id': self.employee_1.id,
+        })
+        leave_request._onchange_leave_dates()
+        self.assertEqual(leave_request.number_of_days, 5)
+
+    def test_number_days_across_year(self):
+        leave_request = self.HrLeave.new({
+            'date_from': '1946-12-23 00:00:00',  # Monday
+            'date_to': '1947-01-03 23:59:59',  # Friday
+            'holiday_status_id': self.holiday_type.id,
+            'employee_id': self.employee_1.id,
+        })
+        leave_request._onchange_leave_dates()
+        self.assertEqual(leave_request.number_of_days, 7)
+
+    def test_number_days_across_year_2(self):
+        leave_request = self.HrLeave.new({
+            'date_from': '1946-12-23 00:00:00',  # Monday
+            'date_to': '1947-01-03 23:59:59',  # Friday
+            'holiday_status_id': self.holiday_type.id,
+            'employee_id': self.employee_2.id,
         })
         leave_request._onchange_leave_dates()
         self.assertEqual(leave_request.number_of_days, 5)


### PR DESCRIPTION
FIX: fix leave number days when requested across years and public holidays are defined for each year

Without this fix, if you take holidays from 2019-12-22 to 2020-01-05 and you have public holidays in 2020, the number of days computed in Odoo don't take care of public holidays in 2020.