### PR TITLE
[12.0][FIX] hr_holiday_public: Fix method return for concatenation

### DIFF
--- a/hr_holidays_public/__manifest__.py
+++ b/hr_holidays_public/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'HR Holidays Public',
-    'version': '12.0.1.0.1',
+    'version': '12.0.1.0.2',
     'license': 'AGPL-3',
     'category': 'Human Resources',
     'author': "Michael Telahun Makonnen, "

--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -93,7 +93,7 @@ class HrHolidaysPublic(models.Model):
                 holidays_filter.append(('country_id', '=', False))
         pholidays = self.search(holidays_filter)
         if not pholidays:
-            return list()
+            return self.env['hr.holidays.public.line']
 
         states_filter = [('year_id', 'in', pholidays.ids)]
         if employee and employee.address_id and employee.address_id.state_id:


### PR DESCRIPTION
Prevent error like `TypeError: can only concatenate list (not "hr.holidays.public.line") to list` when trying to concatenate the result of multiple calls to `get_holidays_list` if any of them is empty