### PR TITLE
[FIX] hr_holiday_public: Delete holidays public

### DIFF
--- a/hr_holidays_public/__manifest__.py
+++ b/hr_holidays_public/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'HR Holidays Public',
-    'version': '12.0.1.0.2',
+    'version': '12.0.1.0.3',
     'license': 'AGPL-3',
     'category': 'Human Resources',
     'author': "Michael Telahun Makonnen, "

--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -143,6 +143,7 @@ class HrHolidaysPublicLine(models.Model):
         'hr.holidays.public',
         'Calendar Year',
         required=True,
+        ondelete='cascade',
     )
     variable_date = fields.Boolean(
         'Date may change',


### PR DESCRIPTION
**Before PR:**

Open a Public Holiday and try to delete it. An error will be raised:

```
The operation cannot be completed:
- Create/update: a mandatory field is not set.
- Delete: another model requires the record being deleted. If possible, archive it instead.

Model: Public Holidays Lines (hr.holidays.public.line), Field: Calendar Year (year_id) 
```

**After PR:**

No error. Public Holidays and all the lines will be removed.