### PR TITLE
[FIX] hr_employee_calendar_planning: link leaves

### DIFF
--- a/hr_employee_calendar_planning/__init__.py
+++ b/hr_employee_calendar_planning/__init__.py
@@ -2,4 +2,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizards
 from .hooks import post_init_hook

--- a/hr_employee_calendar_planning/__manifest__.py
+++ b/hr_employee_calendar_planning/__manifest__.py
@@ -16,6 +16,7 @@
     "data": [
         "security/ir.model.access.csv",
         "views/hr_employee_views.xml",
+        "wizards/wizard_employee_calendar_views.xml",
     ],
     "post_init_hook": "post_init_hook",
 }

--- a/hr_employee_calendar_planning/readme/ROADMAP.rst
+++ b/hr_employee_calendar_planning/readme/ROADMAP.rst
@@ -1,6 +1,3 @@
 
-* Add a wizard for generating next year calendar planning based on current one
-  in batch.
-* Add constraint for avoiding planning lines overlapping.
 * Avoid the regeneration of whole private calendars each time a change is
   detected.

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -42,6 +42,13 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
         cls.employee = cls.env['hr.employee'].create({
             'name': 'Test employee',
         })
+        cls.leave1 = cls.env['resource.calendar.leaves'].create({
+            'name': 'Test leave',
+            'calendar_id': cls.calendar1.id,
+            'resource_id': cls.employee.resource_id.id,
+            'date_from': '2019-06-01',
+            'date_to': '2019-06-10',
+        })
 
     def test_calendar_planning(self):
         self.employee.calendar_ids = [
@@ -80,6 +87,9 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
         self.assertEqual(len(self.employee.calendar_ids), 1)
         self.assertFalse(self.employee.calendar_ids.date_start)
         self.assertFalse(self.employee.calendar_ids.date_end)
+        # Check that the employee leaves are transferred to the new calendar
+        self.assertFalse(self.calendar1.leave_ids)
+        self.assertEqual(self.employee.calendar_id.leave_ids, self.leave1)
 
     def test_post_install_hook_several_calendaries(self):
         self.calendar1.attendance_ids[0].date_from = '2019-01-01'

--- a/hr_employee_calendar_planning/views/hr_employee_views.xml
+++ b/hr_employee_calendar_planning/views/hr_employee_views.xml
@@ -20,4 +20,14 @@
             </field>
         </field>
     </record>
+
+    <act_window id="wizard_assign_calendar_date_range"
+        name="Assign Calendar Date Range"
+        src_model="hr.employee"
+        res_model="wizard.employee.calendar.dates"
+        context="{'default_employee_ids': active_ids, 'employee_ids': active_ids}"
+        view_type="form" view_mode="form"
+        key2="client_action_multi" target="new"
+        groups="hr.group_hr_manager"/>
+
 </odoo>

--- a/hr_employee_calendar_planning/wizards/__init__.py
+++ b/hr_employee_calendar_planning/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard_employee_calendar_dates

--- a/hr_employee_calendar_planning/wizards/wizard_employee_calendar_dates.py
+++ b/hr_employee_calendar_planning/wizards/wizard_employee_calendar_dates.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class WizardEmployeeCalendarDates(models.TransientModel):
+    _name = 'wizard.employee.calendar.dates'
+    _description = 'Assign calendar for a date range to employees'
+
+    employee_ids = fields.Many2many(
+        comodel_name='hr.employee',
+        required=True,
+        string='Employees',
+        help='Assign to these employees',
+    )
+    calendar_id = fields.Many2one(
+        comodel_name='resource.calendar',
+        required=True,
+        string='Calendar',
+        help='Assign this calendar',
+    )
+    date_start = fields.Date(
+        string='From',
+    )
+    date_end = fields.Date(
+        string='To',
+    )
+
+    @api.multi
+    def action_assign_calendar(self):
+        self.ensure_one()
+        employee_cal_obj = self.env['hr.employee.calendar']
+        for employee in self.employee_ids:
+            employee_cal_obj.create({
+                'employee_id': employee.id,
+                'calendar_id': self.calendar_id.id,
+                'date_start': self.date_start,
+                'date_end': self.date_end,
+            })
+        return

--- a/hr_employee_calendar_planning/wizards/wizard_employee_calendar_views.xml
+++ b/hr_employee_calendar_planning/wizards/wizard_employee_calendar_views.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="act_wizard_employee_calendar_dates" model="ir.actions.act_window">
+        <field name="name">Add employees calendar and date range</field>
+        <field name="res_model">wizard.employee.calendar.dates</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <record id="wizard_employee_calendar_dates" model="ir.ui.view">
+        <field name="model">wizard.employee.calendar.dates</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <group>
+                        <field name="employee_ids" widget="many2many_tags"/>
+                        <field name="calendar_id"/>
+                        <field name="date_start"/>
+                        <field name="date_end"/>
+                    </group>
+                </group>
+                <footer>
+                    <button name="action_assign_calendar"
+                            type="object"
+                            string="Assign Calendar"
+                            class="oe_highlight"/>
+                    <button special="cancel" string="Cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
- On the module init, existing employee calendar leaves should be linked
to the employee's new autocalendar.

cc @Tecnativa TT20229