### PR TITLE
[IMP] hr_attendance_report_theoretical_time: recompute attendances

### DIFF
--- a/hr_attendance_report_theoretical_time/__init__.py
+++ b/hr_attendance_report_theoretical_time/__init__.py
@@ -3,3 +3,4 @@
 
 from . import models
 from . import reports
+from . import wizards

--- a/hr_attendance_report_theoretical_time/__manifest__.py
+++ b/hr_attendance_report_theoretical_time/__manifest__.py
@@ -17,6 +17,7 @@
     "data": [
         "security/ir.model.access.csv",
         "security/hr_attendance_report_theoretical_time_security.xml",
+        "wizards/recompute_theoretical_attendance_views.xml",
         "views/hr_holidays_status_views.xml",
         "views/hr_employee_views.xml",
         "reports/hr_attendance_theoretical_time_report_views.xml",

--- a/hr_attendance_report_theoretical_time/readme/CONTRIBUTORS.rst
+++ b/hr_attendance_report_theoretical_time/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * Pedro M. Baeza.
+  * David Vidal

--- a/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
@@ -69,6 +69,28 @@ class TestHrAttendanceReportTheoreticalTime(TestHolidaysComputeDaysBase):
         self.assertEqual(self.attendances[14].theoretical_hours, 8)
         self.assertEqual(self.attendances[15].theoretical_hours, 8)
 
+    def test_theoretical_hours_recompute(self):
+        """Change calendar, and then recompute with the wizard"""
+        # Get rid of 4 hours per day so the theoretical should be 4.
+        self.calendar.attendance_ids.filtered(
+            lambda x: x.hour_from == 14.0).unlink()
+        # The attendances theoretical hours remain at 8 if not recomputed
+        self.assertEqual(self.attendances[0].theoretical_hours, 8)
+        self.assertEqual(self.attendances[1].theoretical_hours, 8)
+        # Then we run the wizard just for day 23
+        wizard = self.env['recompute.theoretical.attendance'].create({
+            'employee_ids': [(4, self.employee_1.ids)],
+            'date_from': '1946-12-23 00:00:00',
+            'date_to': '1946-12-23 23:59:59',
+        })
+        wizard.action_recompute()
+        # Attendances for day 23 are recomputed
+        self.assertEqual(self.attendances[0].theoretical_hours, 4)
+        self.assertEqual(self.attendances[1].theoretical_hours, 4)
+        # Attendances for day 24 remaine as they were
+        self.assertEqual(self.attendances[2].theoretical_hours, 8)
+        self.assertEqual(self.attendances[3].theoretical_hours, 8)
+
     def test_hr_attendance_read_group(self):
         # TODO: Test when having theoretical_hours_start_date set
         # Group by employee

--- a/hr_attendance_report_theoretical_time/views/hr_employee_views.xml
+++ b/hr_attendance_report_theoretical_time/views/hr_employee_views.xml
@@ -9,4 +9,14 @@
             </field>
         </field>
     </record>
+
+    <act_window id="recompute_employee_theoretical_attendance"
+        name="Recompute Theoretical Attendance"
+        src_model="hr.employee"
+        res_model="recompute.theoretical.attendance"
+        context="{'default_employee_ids': active_ids, 'employee_ids': active_ids}"
+        view_type="form" view_mode="form"
+        key2="client_action_multi" target="new"
+        groups="hr_attendance.group_hr_attendance_manager"/>
+
 </odoo>

--- a/hr_attendance_report_theoretical_time/wizards/__init__.py
+++ b/hr_attendance_report_theoretical_time/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import recompute_theoretical_attendance

--- a/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance.py
+++ b/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class RecomputeTheoreticalAttendance(models.TransientModel):
+    _name = 'recompute.theoretical.attendance'
+    _description = 'Recompute Employees Attendances'
+
+    employee_ids = fields.Many2many(
+        comodel_name='hr.employee',
+        required=True,
+        string='Employees',
+        help='Recompute these employees attendances',
+    )
+    date_from = fields.Datetime(
+        string='From',
+        required=True,
+        help='Recompute attendances from this date',
+    )
+    date_to = fields.Datetime(
+        string='To',
+        required=True,
+        help='Recompute attendances up to this date',
+    )
+
+    @api.multi
+    def action_recompute(self):
+        self.ensure_one()
+        attendances = self.env['hr.attendance'].search([
+            ('employee_id', 'in', self.employee_ids.ids),
+            ('check_in', '>=', self.date_from),
+            ('check_out', '<=', self.date_to),
+        ])
+        attendances._compute_theoretical_hours()
+        return {'type': 'ir.actions.act_window_close'}

--- a/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance_views.xml
+++ b/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance_views.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="act_wizard_recompute_theoretical_attendance" model="ir.actions.act_window">
+        <field name="name">Recompute Theoretical Attendances</field>
+        <field name="res_model">recompute.theoretical.attendance</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <record id="recompute_theoretical_attendance_form" model="ir.ui.view">
+        <field name="model">recompute.theoretical.attendance</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <group>
+                        <field name="employee_ids" widget="many2many_tags"/>
+                        <field name="date_from"/>
+                        <field name="date_to"/>
+                    </group>
+                </group>
+                <footer>
+                    <button name="action_recompute"
+                            type="object"
+                            string="Recompute"
+                            class="oe_highlight"/>
+                    <button special="cancel" string="Cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <menuitem action="act_wizard_recompute_theoretical_attendance"
+              id="menu_recompute_theoretical_attendance"
+              parent="hr_attendance.menu_hr_attendance_manage_attendances"
+              sequence="99"
+              groups="hr_attendance.group_hr_attendance_manager"
+    />
+
+</odoo>


### PR DESCRIPTION
- We add a wizard so the already existing attendances can be recomputed
according to an employee calendar change, like a different for a set of
dates that weren't took into consideration in advance, so the wrong
theoretical hours are computed.

cc @Tecnativa TT20229