### PR TITLE
[FIX] Fixed inconsistency - Menu action is called report for all employees - default was only for the current user.

### DIFF
--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
@@ -45,7 +45,7 @@
         <field name="name">Theoretical vs Attended Time Analysis</field>
         <field name="res_model">hr.attendance.theoretical.time.report</field>
         <field name="view_type">form</field>
-        <field name="context">{'search_default_previous_month': 1, 'search_default_current_month': 1, 'search_default_my': 1}</field>
+        <field name="context">{'search_default_previous_month': 1, 'search_default_current_month': 1, 'search_default_my': 0}</field>
         <field name="view_mode">pivot,graph</field>
     </record>
 


### PR DESCRIPTION
The Theoretical time report menu is titled "All Employees" - but if you open it - then you get it filtered for your current user - and not for "All Employees". This fix does change the default filter to be for "All Employees"

Part of #719