### PR TITLE
[10.0][FIX] hr_attendance_rfid

### DIFF
--- a/hr_attendance_rfid/models/hr_employee.py
+++ b/hr_attendance_rfid/models/hr_employee.py
@@ -49,7 +49,7 @@ class HrEmployee(models.Model):
             res['error_message'] = msg
             return res
         try:
-            attendance = employee.attendance_action_change()
+            attendance = employee.sudo().attendance_action_change()
             if attendance:
                 msg = _('Attendance recorded for employee %s') % employee.name
                 _logger.debug(msg)


### PR DESCRIPTION
Basically, in standard odoo v10, when registering attendance, a search is performed in hr_timesheet_sheet.sheet model. That causes access error when registering attendance for the rfid attendance user. Tried to give read access to rfid attendance user, but that did not work.

At the end people is giving extra permissions to rfid user which is dangerous and wrong. Better this patch IMHO.

cc @hveficent 