### PR TITLE
[12.0][IMP] hr_expense_cancel : Cancel vendor bills from hr_expense

### DIFF
--- a/hr_expense_cancel/README.rst
+++ b/hr_expense_cancel/README.rst
@@ -88,6 +88,7 @@ Contributors
   * Ernesto Tejeda
 
 * Danh Vo  <https://github.com/danhvophuong>
+* Saran Lim. <saranl@ecosoft.co.th>
 
 Maintainers
 ~~~~~~~~~~~

--- a/hr_expense_cancel/readme/CONTRIBUTORS.rst
+++ b/hr_expense_cancel/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
   * Ernesto Tejeda
 
 * Danh Vo  <https://github.com/danhvophuong>
+* Saran Lim. <saranl@ecosoft.co.th>

--- a/hr_expense_cancel/static/description/index.html
+++ b/hr_expense_cancel/static/description/index.html
@@ -436,6 +436,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </li>
 <li>Danh Vo  &lt;<a class="reference external" href="https://github.com/danhvophuong">https://github.com/danhvophuong</a>&gt;</li>
+<li>Saran Lim. &lt;<a class="reference external" href="mailto:saranl&#64;ecosoft.co.th">saranl&#64;ecosoft.co.th</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Step to error:
1. create expense normal process
2. Submit to Manager > Approve > Create Vendor Bill
3. Post Journal Entries and click cancel
4. when you click cancel it will showed message error.
`You cannot do this modification on a reconciled entry. You can just change some non legal fields or you must unreconcile first.`

IMP : Collaborative support module hr_expense_cancel and hr_expense_invoice.
you can cancel when create invoice from hr_expense.