### PR TITLE
[12.0][FIX] hr_attendance_report_theoretical_time: menu permissions

### DIFF
--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
@@ -49,6 +49,11 @@
         <field name="view_mode">pivot,graph</field>
     </record>
 
+    <record id="hr_attendance.menu_hr_attendance_report" model="ir.ui.menu">
+        <field name="groups_id"
+               eval="[(4, ref('hr_attendance.group_hr_attendance'))]"/>
+    </record>
+
     <menuitem id="menu_hr_attendance_report"
               name="Attendances Analysis"
               parent="hr_attendance.menu_hr_attendance_report"
@@ -61,7 +66,7 @@
               name="Theoretical vs Attended Time"
               parent="hr_attendance.menu_hr_attendance_report"
               sequence="15"
-              groups="hr_attendance.group_hr_attendance_user"
+              groups="hr_attendance.group_hr_attendance"
     />
 
     <menuitem id="menu_hr_attendance_theoretical_report"

--- a/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.xml
+++ b/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.xml
@@ -52,7 +52,7 @@
               name="Select Employees"
               action="wizard_theoretical_time_act_window"
               parent="menu_hr_attendance_theoretical_root"
-              groups="hr_attendance.group_hr_attendance"
+              groups="hr_attendance.group_hr_attendance_user"
               sequence="25"
     />
 


### PR DESCRIPTION
- Although the minor permission to access the theoretical time report is
"Manual Attendance", the menu wasn't accessible due to permissions.
- Record rules also prevent such users from seeing other employees
attendances.

cc @Tecnativa TT20784