### PR TITLE
[12.0][REF][WIP] hr_holidays_public

### DIFF
--- a/hr_holidays_public/__manifest__.py
+++ b/hr_holidays_public/__manifest__.py
@@ -18,6 +18,7 @@
     'data': [
         'security/ir.model.access.csv',
         'views/hr_holidays_public_view.xml',
+        'views/hr_leave.xml',
         'views/hr_leave_type.xml',
         'wizards/holidays_public_next_year_wizard.xml',
     ],

--- a/hr_holidays_public/models/hr_leave.py
+++ b/hr_holidays_public/models/hr_leave.py
@@ -2,11 +2,72 @@
 # Copyright 2018 Brainbean Apps
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, fields, models
 
 
 class HrLeave(models.Model):
     _inherit = 'hr.leave'
+
+    holiday_type = fields.Selection(
+        selection_add=[('public', 'Public Holidays')]
+    )
+
+    country_id = fields.Many2one(
+        'res.country',
+        'Country'
+    )
+
+    state_ids = fields.Many2many(
+        'res.country.state',
+        'hr_leave_state_rel',
+        'leave_id',
+        'state_id',
+        'Related States'
+    )
+
+    _sql_constraints = [
+        ('type_value', "CHECK(1=1)", "Remove Constraint"),
+        ]
+
+    @api.multi
+    def action_validate(self):
+        public = self.filtered(lambda h: h.holiday_type == 'public')
+        no_public = self.filtered(lambda h: h.holiday_type != 'public')
+        public.write({'state': 'validate'})
+        for holiday in public:
+            domain = []
+            if holiday.country_id:
+                domain = [
+                    ('address_id.country_id', '=', holiday.country_id.id)
+                ]
+            if holiday.state_ids:
+                domain.append((
+                    'address_id.state_id', 'in', holiday.state_ids.ids
+                ))
+            employees = self.env['hr.employee'].search(domain)
+            values = [holiday._prepare_holiday_values(employee) for employee in
+                      employees]
+            leaves = self.env['hr.leave'].with_context(
+                tracking_disable=True,
+                mail_activity_automation_skip=True,
+                leave_fast_create=True,
+                is_public_holidays=holiday.holiday_type == 'public',
+                # is_public_holidays=False,
+            ).create(values)
+            leaves.action_approve()
+        return super(HrLeave, no_public).action_validate()
+
+    @api.onchange('holiday_type')
+    def _onchange_type(self):
+        if self.holiday_type == 'public':
+            self.employee = False
+            self.category_id = False
+            self.mode_company_id = False
+            self.department_id = False
+        else:
+            self.country_id = False
+            self.state_ids = [(6, 0, [])]
+            super()._onchange_type()
 
     def _get_number_of_days(self, date_from, date_to, employee_id):
         if (self.holiday_status_id.exclude_public_holidays or
@@ -22,3 +83,13 @@ class HrLeave(models.Model):
             date_to,
             employee_id,
         )
+
+    @api.multi
+    def _create_resource_leave(self):
+        public = self.filtered(
+            lambda r: r.holiday_type == 'public'
+        ).with_context(is_public_holidays=True)
+        no_public = self.filtered(lambda r: r.holiday_type != 'public')
+        super(HrLeave, public)._create_resource_leave()
+        super(HrLeave, no_public)._create_resource_leave()
+        return True

--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -2,60 +2,11 @@
 # Copyright 2018 Brainbean Apps
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
-from odoo.addons.resource.models.resource import Intervals
-
-from pytz import timezone
-from datetime import datetime, time
-from dateutil import rrule
+from odoo import api, fields, models
 
 
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'
-
-    def _public_holidays_leave_intervals(self, start_dt, end_dt, employee_id,
-                                         tz):
-        """Get the public holidays for the current employee and given dates in
-        the format expected by resource methods.
-
-        :param: start_dt: Initial datetime.
-        :param: end_dt: End datetime.
-        :param: employee_id: Employee ID. It can be false.
-        :return: List of tuples with (start_date, end_date) as elements.
-        """
-        HrHolidaysPublic = self.env['hr.holidays.public']
-
-        leaves = []
-        if start_dt.year != end_dt.year:
-            # This fixes the case of leave request asked over 2 years.
-            #
-            # adding 1 year to end_dt for rrule to retrieve correct years for
-            # public holidays to work
-            # rrule.rrule(rrule.YEARLY, dtstart=2019-12-22, until=2020-01-05)
-            # gives [2019]
-            # rrule.rrule(rrule.YEARLY, dtstart=2019-12-22, until=2021-01-05)
-            # gives [2019, 2020]
-            end_dt = end_dt.replace(year=end_dt.year+1)
-
-        for day in rrule.rrule(rrule.YEARLY, dtstart=start_dt, until=end_dt):
-            lines = HrHolidaysPublic.get_holidays_list(
-                day.year, employee_id=employee_id,
-            )
-            for line in lines:
-                leaves.append(
-                    (
-                        datetime.combine(
-                            line.date,
-                            time.min
-                        ).replace(tzinfo=tz),
-                        datetime.combine(
-                            line.date,
-                            time.max
-                        ).replace(tzinfo=tz),
-                        line
-                    ),
-                )
-        return Intervals(leaves)
 
     @api.multi
     def _leave_intervals(self, start_dt, end_dt, resource=None, domain=None):
@@ -65,13 +16,21 @@ class ResourceCalendar(models.Model):
             resource=resource,
             domain=domain,
         )
-        if self.env.context.get('exclude_public_holidays'):
-            tz = timezone((resource or self).tz)
-            public_holidays = self._public_holidays_leave_intervals(
-                start_dt,
-                end_dt,
-                self.env.context.get('employee_id', False),
-                tz
-            )
-            res = res | public_holidays
+        if not self.env.context.get('exclude_public_holidays'):
+            intervals = []
+            for start, end, record in res:
+                if not record.is_public_holidays:
+                    intervals |= res
+            return intervals
         return res
+
+
+class ResourceCalendarLeaves(models.Model):
+    _inherit = "resource.calendar.leaves"
+
+    def compute_is_public(self):
+        return self.env.context.get('is_public_holidays', False)
+
+    is_public_holidays = fields.Boolean(
+        default=lambda r: r.compute_is_public()
+    )

--- a/hr_holidays_public/tests/test_holidays_calculation.py
+++ b/hr_holidays_public/tests/test_holidays_calculation.py
@@ -66,6 +66,8 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
                 }),
             ],
         })
+        cls.public_holiday_global.generate_public_holidays()
+
         cls.public_holiday_country = cls.HrHolidaysPublic.create({
             'year': 1946,
             'country_id': cls.address_2.country_id.id,
@@ -83,6 +85,7 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
                 }),
             ],
         })
+        cls.public_holiday_country.generate_public_holidays()
 
         cls.public_holiday_global_1947 = cls.HrHolidaysPublic.create({
             'year': 1947,
@@ -97,6 +100,7 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
                 }),
             ],
         })
+        cls.public_holiday_global_1947.generate_public_holidays()
 
         cls.holiday_type = cls.HrLeaveType.create({
             'name': 'Leave Type Test',

--- a/hr_holidays_public/tests/test_holidays_public.py
+++ b/hr_holidays_public/tests/test_holidays_public.py
@@ -6,8 +6,6 @@ from odoo.tests.common import TransactionCase
 
 from odoo.exceptions import UserError, ValidationError
 
-from datetime import date
-
 
 class TestHolidaysPublic(TransactionCase):
     at_install = False
@@ -113,32 +111,6 @@ class TestHolidaysPublic(TransactionCase):
                 'state_ids': [(6, 0, [self.env.ref('base.state_us_35').id])]
             })
 
-    def test_isnot_holiday(self):
-        # ensures that if given a date that is not an holiday it returns none
-        self.assertFalse(self.holiday_model.is_public_holiday(
-            date(1995, 12, 10)
-        ))
-
-    def test_is_holiday(self):
-        # ensures that correct holidays are identified
-        self.assertTrue(self.holiday_model.is_public_holiday(
-            date(1995, 10, 14)
-        ))
-
-    def test_isnot_holiday_in_country(self):
-        # ensures that correct holidays are identified for a country
-        self.assertFalse(self.holiday_model.is_public_holiday(
-            date(1994, 11, 14),
-            employee_id=self.employee.id
-        ))
-
-    def test_is_holiday_in_country(self):
-        # ensures that correct holidays are identified for a country
-        self.assertTrue(self.holiday_model.is_public_holiday(
-            date(1994, 10, 14),
-            employee_id=self.employee.id
-        ))
-
     def test_holiday_line_year(self):
         # ensures that line year and holiday year are the same
         holiday4 = self.holiday_model.create({
@@ -150,51 +122,6 @@ class TestHolidaysPublic(TransactionCase):
                 'date': '1995-11-14',
                 'year_id': holiday4.id
             })
-
-    def test_list_holidays_in_list_country_specific(self):
-        # ensures that correct holidays are identified for a country
-        lines = self.holiday_model.get_holidays_list(
-            1994, employee_id=self.employee.id)
-        res = lines.filtered(
-            lambda r: r.date == date(1994, 10, 14)
-        )
-        self.assertEqual(len(res), 1)
-        self.assertEqual(len(lines), 1)
-
-    def test_list_holidays_in_list(self):
-        # ensures that correct holidays are identified for a country
-        lines = self.holiday_model.get_holidays_list(1995)
-        res = lines.filtered(
-            lambda r: r.date == date(1995, 10, 14)
-        )
-        self.assertEqual(len(res), 1)
-        self.assertEqual(len(lines), 3)
-
-    def test_create_next_year_public_holidays(self):
-        self.wizard_next_year.new().create_public_holidays()
-        lines = self.holiday_model.get_holidays_list(1996)
-        res = lines.filtered(
-            lambda r: r.date == date(1996, 10, 14)
-        )
-        self.assertEqual(len(res), 1)
-        self.assertEqual(len(lines), 3)
-
-    def test_create_year_2000_public_holidays(self):
-        ph_start_ids = self.holiday_model.search([('year', '=', 1994)])
-        val = {
-            'template_ids': ph_start_ids,
-            'year': 2000
-        }
-        wz_create_ph = self.wizard_next_year.new(values=val)
-
-        wz_create_ph.create_public_holidays()
-
-        lines = self.holiday_model.get_holidays_list(2000)
-        self.assertEqual(len(lines), 2)
-
-        res = lines.filtered(
-            lambda r: r.year_id.country_id.id == self.env.ref('base.sl').id)
-        self.assertEqual(len(res), 1)
 
     def test_february_29th(self):
         # Ensures that users get a UserError (not a nasty Exception) when

--- a/hr_holidays_public/views/hr_holidays_public_view.xml
+++ b/hr_holidays_public/views/hr_holidays_public_view.xml
@@ -17,27 +17,33 @@
         <field name="model">hr.holidays.public</field>
         <field name="arch" type="xml">
             <form string="Public Holidays">
-                <group name="group_main">
-                    <group name="group_main_left">
-                        <field name="year"/>
-                        <field name="country_id"/>
+                <header>
+                    <button name="generate_public_holidays" class="oe_highlight"
+                            string="Generate Leaves" type="object"/>
+                </header>
+                <sheet>
+                    <group name="group_main">
+                        <group name="group_main_left">
+                            <field name="year"/>
+                            <field name="country_id"/>
+                        </group>
+                        <group name="group_main_right">
+                            <!-- Left empty for extensions -->
+                        </group>
                     </group>
-                    <group name="group_main_right">
-                        <!-- Left empty for extensions -->
+                    <group string="Public Holidays" name="group_detail">
+                        <field name="line_ids" nolabel="1">
+                            <tree string="Public Holidays"
+                                editable="top">
+                                <field name="date" attrs="{'readonly':[['variable_date', '=', False]]}" />
+                                <field name="name" />
+                                <field name="state_ids" widget="many2many_tags"
+                                    domain="[('country_id','=',parent.country_id)]" />
+                                <field name="variable_date"/>
+                            </tree>
+                        </field>
                     </group>
-                </group>
-                <group string="Public Holidays" name="group_detail">
-                    <field name="line_ids" nolabel="1">
-                        <tree string="Public Holidays"
-                            editable="top">
-                            <field name="date" attrs="{'readonly':[['variable_date', '=', False]]}" />
-                            <field name="name" />
-                            <field name="state_ids" widget="many2many_tags"
-                                domain="[('country_id','=',parent.country_id)]" />
-                            <field name="variable_date"/>
-                        </tree>
-                    </field>
-                </group>
+                </sheet>
             </form>
         </field>
     </record>

--- a/hr_holidays_public/views/hr_leave.xml
+++ b/hr_holidays_public/views/hr_leave.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="hr_leave_view_form_manager" model="ir.ui.view">
+        <field name="name">hr.leave.form</field>
+        <field name="model">hr.leave</field>
+        <field name="inherit_id" ref="hr_holidays.hr_leave_view_form_manager" />
+        <field name="arch" type="xml">
+            <field name="department_id" position="after">
+                <field name="country_id" groups="hr_holidays.group_hr_holidays_user"
+                       attrs="{'invisible': [('holiday_type', '!=', 'public')]}"/>
+                <field name="state_ids" groups="hr_holidays.group_hr_holidays_user"
+                       widget="many2many_tags" domain="[('country_id','=', country_id)]"
+                       attrs="{'invisible': [('holiday_type', '!=', 'public')]}"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The purpose of this PR is to break the ice regarding the conversation in #646. 
This is a first approach on how the module would be refactored so it manages a new type of leave `by region`, the same way Odoo can manage leaves by category, by department or by company.
My idea is that the definition of the public holidays calendar remains the same, but a new button `Generate Leaves` is added, which will automatically create the leave type and all the `hr.leaves` related to that.

Known Issues:
- [ ] Public holidays should be able to overlap with other kind of leaves
- [ ] Can't modify the calendar once leaves are generated