### PR TITLE
[11.0][FIX] hr_holidays_validity_date: related readonly

### DIFF
--- a/hr_holidays_validity_date/models/hr_holidays.py
+++ b/hr_holidays_validity_date/models/hr_holidays.py
@@ -27,8 +27,11 @@ class HrHolidays(models.Model):
     _inherit = "hr.holidays"
 
     warning = fields.Char(compute='_compute_warning_range')
-    restrict_dates = fields.Boolean(string='Restrict dates',
-                                    related='holiday_status_id.restrict_dates')
+    restrict_dates = fields.Boolean(
+        string='Restrict dates',
+        related='holiday_status_id.restrict_dates',
+        readonly=True,
+    )
 
     @api.model
     def _utc_to_tz(self, date):


### PR DESCRIPTION
Set related field as readonly to prevent permission issues when the user isnt allowed to write in `hr.holidays.status` model.
I think it can be fast-tracked. @pedrobaeza @alexey-pelykh @etobella 