### PR TITLE
[10.0][FIX] Call correct process/function to validate holidays/leave

### DIFF
--- a/hr_holidays_imposed_days/models/hr_imposed_holidays.py
+++ b/hr_holidays_imposed_days/models/hr_imposed_holidays.py
@@ -59,7 +59,11 @@ class HrHolidaysImposed(models.Model):
                 leave._onchange_date_from()
                 created |= leave
             if rec.auto_confirm:
-                created.action_validate()
+                need_double_validation = created.filtered(
+                    lambda h: h.double_validation)
+                created.action_approve()
+                if need_double_validation:
+                    need_double_validation.action_validate()
 
     def _get_number_of_days(self, date_from, date_to):
         """Returns a float equals to the timedelta between


### PR DESCRIPTION
To match with expected behavior, we have to call first the `action_approve()` and then `action_validate()` (only if necessary).
For example, this order is required to works with `hr_timesheet_holiday` module (to create automatically holidays analytic lines).