### PR TITLE
[12.0][IMP] hr_holidays_public: improve wizard

### DIFF
--- a/hr_holidays_public/views/hr_holidays_public_view.xml
+++ b/hr_holidays_public/views/hr_holidays_public_view.xml
@@ -30,7 +30,7 @@
                     <field name="line_ids" nolabel="1">
                         <tree string="Public Holidays"
                             editable="top">
-                            <field name="date" attrs="{'readonly':[['variable_date', '=', False]]}" />
+                            <field name="date"/>
                             <field name="name" />
                             <field name="state_ids" widget="many2many_tags"
                                 domain="[('country_id','=',parent.country_id)]" />

--- a/hr_holidays_public/wizards/holidays_public_next_year_wizard.py
+++ b/hr_holidays_public/wizards/holidays_public_next_year_wizard.py
@@ -13,89 +13,129 @@ class HolidaysPublicNextYearWizard(models.TransientModel):
     _name = 'public.holidays.next.year.wizard'
     _description = 'Creates public holidays from existing ones'
 
-    template_ids = fields.Many2many(
+    template_id = fields.Many2one(
         comodel_name='hr.holidays.public',
-        string='Templates',
-        help='Select the public holidays to use as template. '
-        'If not set, latest public holidays of each country will be used. '
-        'Only the last templates of each country for each year will '
-        'be taken into account (If you select templates from 2012 and 2015, '
-        'only the templates from 2015 will be taken into account.',)
+        string='Template',
+        help='Select the public holidays to use as template.',
+    )
+
     year = fields.Integer(
         help='Year for which you want to create the public holidays. '
         'By default, the year following the template.',
+        default=fields.Date.today().year + 1
     )
+    country_id = fields.Many2one(
+        'res.country', string='Country', related='template_id.country_id'
+    )
+
+    pending_lines = fields.One2many(
+        'hr.holidays.public.line.transient', inverse_name='wizard_id'
+    )
+
+    warning_existing = fields.Boolean(
+        compute='_compute_warning_existing', store=True,
+    )
+
+    @api.onchange('template_id')
+    def _onchange_template_id(self):
+        self.ensure_one()
+        self.pending_lines = [(6, 0, [])]
+        if not self.template_id:
+            return
+        year = self.template_id.year + 1
+        vals_list = []
+        for line in self.template_id.line_ids.filtered(
+            lambda r: r.variable_date
+        ):
+            date = fields.Datetime.from_string(line.date)
+            date = fields.Datetime.to_string(date.replace(year=year))
+            data = (0, 0, {
+                'name': line.name,
+                'date': date,
+                'line_id': line.id,
+                'state_ids': [(6, 0, line.state_ids.ids)],
+            })
+            vals_list.append(data)
+        self.year = year
+        self.pending_lines = vals_list
+
+    @api.onchange('year')
+    def _onchange_year(self):
+        self.ensure_one()
+        for line in self.pending_lines:
+            date = fields.Date.from_string(line.date)
+            date = fields.Date.to_string(date.replace(year=self.year))
+            line.date = date
+
+    @api.depends('year', 'template_id')
+    def _compute_warning_existing(self):
+        for record in self:
+            existing = self.env['hr.holidays.public'].search([
+                ('country_id', '=', record.country_id.id),
+                ('year', '=', record.year)
+            ], limit=1)
+            record.warning_existing = len(existing) > 0
 
     @api.multi
     def create_public_holidays(self):
-
         self.ensure_one()
-
-        last_ph_dict = {}
-
-        ph_env = self.env['hr.holidays.public']
-        pholidays = self.template_ids or ph_env.search([])
-
-        if not pholidays:
+        # Handling this rare case would mean quite a lot of
+        # complexity because previous or next day might also be a
+        # public holiday.
+        if any([(
+            l.date.month == 2 and l.date.day == 29
+        ) for l in self.template_id.line_ids]):
             raise UserError(_(
-                'No Public Holidays found as template. '
-                'Please create the first Public Holidays manually.'))
+                'You cannot use as template the public holidays '
+                'of a year that includes public holidays on 29th of February'
+                '(2016, 2020...), please select a template from '
+                'another year.'))
 
-        for ph in pholidays:
-
-            last_ph_country = last_ph_dict.get(ph.country_id, False)
-
-            if last_ph_country:
-                if last_ph_country.year < ph.year:
-                    last_ph_dict[ph.country_id] = ph
-            else:
-                last_ph_dict[ph.country_id] = ph
-
-        new_ph_ids = []
-        for last_ph in last_ph_dict.values():
-
-            new_year = self.year or last_ph.year + 1
-
-            new_ph_vals = {
-                'year': new_year,
+        new_calendar = self.env['hr.holidays.public'].create(
+            {
+                'year': self.year,
+                'country_id': self.country_id.id,
+                'line_ids': [],
             }
+        )
+        for line in self.template_id.line_ids.filtered(
+            lambda r: not r.variable_date
+        ):
+            date = fields.Date.from_string(line.date)
+            date = date.replace(year=self.year)
+            new_vals = {
+                'year_id': new_calendar.id,
+                'date': fields.Date.to_string(date),
+            }
+            line.copy(new_vals)
 
-            new_ph = last_ph.copy(new_ph_vals)
-
-            new_ph_ids.append(new_ph.id)
-
-            for last_ph_line in last_ph.line_ids:
-                feb_29 = (
-                    last_ph_line.date.month == 2 and
-                    last_ph_line.date.day == 29)
-
-                if feb_29:
-                    # Handling this rare case would mean quite a lot of
-                    # complexity because previous or next day might also be a
-                    # public holiday.
-                    raise UserError(_(
-                        'You cannot use as template the public holidays '
-                        'of a year that '
-                        'includes public holidays on 29th of February '
-                        '(2016, 2020...), please select a template from '
-                        'another year.'))
-
-                new_date = last_ph_line.date.replace(year=new_year)
-
-                new_ph_line_vals = {
-                    'date': new_date,
-                    'year_id': new_ph.id,
-                }
-                last_ph_line.copy(new_ph_line_vals)
-
-        domain = [['id', 'in', new_ph_ids]]
+        for line in self.pending_lines:
+            new_vals = {
+                'year_id': new_calendar.id,
+                'name': line.name,
+                'date': line.date,
+            }
+            line.line_id.copy(new_vals)
 
         action = {
             'type': 'ir.actions.act_window',
             'name': 'New public holidays',
             'view_mode': 'tree,form',
             'res_model': 'hr.holidays.public',
-            'domain': domain
+            'res_id': new_calendar.id
         }
 
         return action
+
+
+class PublicHolidaysLineTransient(models.TransientModel):
+
+    _name = 'hr.holidays.public.line.transient'
+    _description = 'Wizard Public Holiday Lines'
+    _order = 'date'
+
+    name = fields.Char(string='Description')
+    date = fields.Date(string='Date')
+    wizard_id = fields.Many2one('public.holidays.next.year.wizard')
+    line_id = fields.Many2one('hr.holidays.public.line')
+    state_ids = fields.Many2many('res.country.state', readonly=True)

--- a/hr_holidays_public/wizards/holidays_public_next_year_wizard.xml
+++ b/hr_holidays_public/wizards/holidays_public_next_year_wizard.xml
@@ -9,44 +9,49 @@
         <field name="model">public.holidays.next.year.wizard</field>
         <field name="arch" type="xml">
             <form string="Create Next Year Public Holidays">
+                <field name="warning_existing" invisible="1"/>
+                <div class="alert alert-warning"
+                     aria-label="Warning"
+                     title="Warning"
+                     role="alert"
+                     attrs="{'invisible': [('warning_existing', '=', False)]}"
+                     style="margin-bottom:0px;">
+                    <p>
+                        <i class="fa fa-info-circle"/>
+                        <span>Warning: A public holidays calendar for this country and year already exists!</span>
+                    </p>
+                </div>
                 <sheet>
                     <div>
-                            Use this wizard to create public holidays based on the
-                            existing ones.<br/>
-                            Only the last templates of each country
-                            will be taken into account (If you select templates
-                            from 2012 and 2015 of the same country; '
-                            only the templates from 2015 will be taken into
-                            account).
+                        Use this wizard to create public holidays based on existing ones.
+                        If this is the first time you are creating a calendar,
+                        you should create it manually since this wizard takes
+                        previous years' calendars as templates.<br/>
                     </div>
-
+                    <group>
+                        <group><field name="template_id" required="1" options="{'no_create': True}"/></group>
+                        <group>
+                            <field name="country_id"/>
+                            <field name="year"/>
+                        </group>
+                    </group>
+                    <div>
+                        Days to review are those that were marked with variable date
+                        in template's calendar. Here you can modify the date in case
+                        it is not the same than in the template.
+                    </div>
                     <notebook>
-                        <page name="defaults" string="Defaults">
-                            <div>
-                            By default, the most recent public holidays
-                            for each country are used as template to create
-                            public holidays for the year following the templates.
-                            <br/><br/>
-                            Normally, you should not need to input anything in
-                            optional fields and only need to click on the button
-                            "Create".
-                            </div>
-                        </page>
-                        <page name="optional" string="Optional">
-                            <div>
-                            The below optional fields are here only to handle
-                            special situations like "2011 was a special year with
-                            an additional public holiday for the 150th
-                            anniversary of the Italian unification, so you want to
-                            replicate the 2010 Italian holidays to 2012."
-                            </div>
-                            <group>
-                                <field name="template_ids" />
-                                <field name="year" />
-                            </group>
+                        <page name="pending" string="Days to Review">
+                            <field name="pending_lines">
+                                <tree editable="bottom" create="0">
+                                    <field name="date"/>
+                                    <field name="name"/>
+                                    <field name="state_ids" widget="many2many_tags"/>
+                                    <field name="line_id" invisible="1"/>
+                                </tree>
+                            </field>
                         </page>
                     </notebook>
-
                 </sheet>
                 <footer>
                     <button name="create_public_holidays" string="Create" type="object" class="btn-primary"/>


### PR DESCRIPTION
Refactor of the public holidays generator wizard to take into account that public holidays are not always the same day every year. It follows the discussion in #755 

Before this PR the wizard took the latest template of every country and generated the new calendars. It was very nice because you could generate all the different countries calendars with just one click, but it wasn't useful at all if after this you had to go one by one correcting the dates that changed (Easter is the most common example). Also the field `variable_date` wasn't serving any purpose.

Now, when opening the wizard you have to select a template and which year you want to generate. It will display all the lines that were marked as `variable_date` where you will have the chance of changing the proposed date in case it is necessary. After doing this, a new calendar will be created for the country of the template with the lines where `variable_date` is false with the updated year, and with the lines you just solved.
It is true that you now have to create calendars one by one, but at least you create them correctly, which in my opinion is better that creating all at the same time and correcting them one by one later...

![imagen](https://user-images.githubusercontent.com/47532076/71977867-3a7c8900-321a-11ea-999a-749083dfd001.png)

What do you think? @kensshiro @SSanfilippo @etobella @alexey-pelykh @pedrobaeza 