### PR TITLE
[11.0][IMP] hr_autoclose: max_hours_hook

### DIFF
--- a/hr_attendance_autoclose/models/hr_attendance.py
+++ b/hr_attendance_autoclose/models/hr_attendance.py
@@ -34,8 +34,7 @@ class HrAttendance(models.Model):
     @api.multi
     def autoclose_attendance(self, reason):
         self.ensure_one()
-        max_hours = self.employee_id.company_id. \
-            attendance_maximum_hours_per_day
+        max_hours = self.employee_id.get_max_hours_per_day()
         leave_time = datetime.strptime(
             self.check_in, DEFAULT_SERVER_DATETIME_FORMAT
         ) + timedelta(hours=max_hours)
@@ -48,8 +47,7 @@ class HrAttendance(models.Model):
     @api.multi
     def needs_autoclose(self):
         self.ensure_one()
-        max_hours = self.employee_id.company_id.\
-            attendance_maximum_hours_per_day
+        max_hours = self.employee_id.get_max_hours_per_day()
         close = not self.employee_id.no_autoclose
         return close and max_hours and self.open_worked_hours > max_hours
 

--- a/hr_attendance_autoclose/models/hr_employee.py
+++ b/hr_attendance_autoclose/models/hr_employee.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Creu Blanca
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class HrEmployee(models.Model):
@@ -9,3 +9,8 @@ class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
     no_autoclose = fields.Boolean(string='Don\'t Autoclose Attendances')
+
+    @api.multi
+    def get_max_hours_per_day(self):
+        self.ensure_one()
+        return self.company_id.attendance_maximum_hours_per_day


### PR DESCRIPTION
This module first got this information from employee's companies but there is a PR proposing to take this attribute from employee's calendar in https://github.com/OCA/hr/pull/761. It could also be retrieved on employee's job or directly setting the max time employee per employee.
Since there are several criteria on how to decide the maximum hours an employee should work in a day I decided to create this hook and let everyone chose how they prefer to compute this field.

@etobella @AaronHForgeFlow 