### PR TITLE
[12.0][FIX] hr_employee_display_own_info : can't see fields

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = babel,dateutil,mock,odoo,openupgradelib,psycopg2,pytz,setuptools,werkzeug

--- a/hr_employee_display_own_info/README.rst
+++ b/hr_employee_display_own_info/README.rst
@@ -55,6 +55,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Andrea Stirpe <a.stirpe@onestein.nl>
+* Saran Lim. <saranl@ecosoft.co.th>
 
 Maintainers
 ~~~~~~~~~~~

--- a/hr_employee_display_own_info/models/hr_employee.py
+++ b/hr_employee_display_own_info/models/hr_employee.py
@@ -19,3 +19,38 @@ class HrEmployee(models.Model):
     employee_display_personal_data = fields.Boolean(
         compute='_compute_display_personal_data'
     )
+
+    # Citizenship & Other Information
+    country_id = fields.Many2one(groups=False)
+    identification_id = fields.Char(groups=False)
+    passport_id = fields.Char(groups=False)
+    bank_account_id = fields.Many2one(groups=False)
+
+    # Contact Information
+    address_home_id = fields.Many2one(groups=False)
+    emergency_contact = fields.Char(groups=False)
+    emergency_phone = fields.Char(groups=False)
+    km_home_work = fields.Integer(groups=False)
+
+    # Status
+    gender = fields.Selection(groups=False)
+    marital = fields.Selection(groups=False)
+    children = fields.Integer(groups=False)
+
+    # Birth
+    birthday = fields.Date(groups=False)
+    place_of_birth = fields.Char(groups=False)
+    country_of_birth = fields.Many2one(groups=False)
+
+    # Work Permit
+    visa_no = fields.Char(groups=False)
+    permit_no = fields.Char(groups=False)
+    visa_expire = fields.Date(groups=False)
+
+    # Education
+    certificate = fields.Selection(groups=False)
+    study_field = fields.Char(groups=False)
+    study_school = fields.Char(groups=False)
+
+    google_drive_link = fields.Char(groups=False)
+    additional_note = fields.Text(groups=False)

--- a/hr_employee_display_own_info/readme/CONTRIBUTORS.rst
+++ b/hr_employee_display_own_info/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Andrea Stirpe <a.stirpe@onestein.nl>
+* Saran Lim. <saranl@ecosoft.co.th>

--- a/hr_employee_display_own_info/static/description/index.html
+++ b/hr_employee_display_own_info/static/description/index.html
@@ -402,6 +402,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#id4">Contributors</a></h2>
 <ul class="simple">
 <li>Andrea Stirpe &lt;<a class="reference external" href="mailto:a.stirpe&#64;onestein.nl">a.stirpe&#64;onestein.nl</a>&gt;</li>
+<li>Saran Lim. &lt;<a class="reference external" href="mailto:saranl&#64;ecosoft.co.th">saranl&#64;ecosoft.co.th</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/hr_employee_display_own_info/views/hr_employee.xml
+++ b/hr_employee_display_own_info/views/hr_employee.xml
@@ -16,6 +16,21 @@
                 <attribute name="attrs">{'invisible': [('employee_display_personal_data', '!=', True)]}</attribute>
                 <attribute name="groups"></attribute>
             </xpath>
+            <xpath expr="//field[@name='km_home_work']" position="attributes">
+                <attribute name="groups"></attribute>
+            </xpath>
+            <xpath expr="//field[@name='place_of_birth']" position="attributes">
+                <attribute name="groups"></attribute>
+            </xpath>
+            <xpath expr="//field[@name='country_of_birth']" position="attributes">
+                <attribute name="groups"></attribute>
+            </xpath>
+            <xpath expr="//field[@name='identification_id']" position="attributes">
+                <attribute name="groups"></attribute>
+            </xpath>
+            <xpath expr="//field[@name='passport_id']" position="attributes">
+                <attribute name="groups"></attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
This PR fixed bug user is not `hr.group_hr_user` and can't see fields in `Private Information` tab
![Selection_001](https://user-images.githubusercontent.com/20896369/74223524-7909d580-4ce9-11ea-841c-a780c86d1f86.png)

In core odoo write groups `hr.group_hr_user` each field in python code.