### PR TITLE
[FIX] hr_holidays_public: avoid object mixing

### DIFF
--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -2,7 +2,7 @@
 # Copyright 2018 Brainbean Apps
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import models
 from odoo.addons.resource.models.resource import Intervals
 
 from pytz import timezone
@@ -36,7 +36,6 @@ class ResourceCalendar(models.Model):
             # rrule.rrule(rrule.YEARLY, dtstart=2019-12-22, until=2021-01-05)
             # gives [2019, 2020]
             end_dt = end_dt.replace(year=end_dt.year+1)
-
         for day in rrule.rrule(rrule.YEARLY, dtstart=start_dt, until=end_dt):
             lines = HrHolidaysPublic.get_holidays_list(
                 day.year, employee_id=employee_id,
@@ -52,12 +51,11 @@ class ResourceCalendar(models.Model):
                             line.date,
                             time.max
                         ).replace(tzinfo=tz),
-                        line
+                        self.env['resource.calendar.leaves']
                     ),
                 )
         return Intervals(leaves)
 
-    @api.multi
     def _leave_intervals(self, start_dt, end_dt, resource=None, domain=None):
         res = super()._leave_intervals(
             start_dt=start_dt,


### PR DESCRIPTION
Whenever a holiday and a leave were overlaping we could get an object
mixing error. We solve it passing it to the class Intervals as a
resource.calendar.leaves object with its proper date info.

Solves https://github.com/OCA/hr/issues/646

cc @Tecnativa TT21352