### PR TITLE
[12.0][FIX] hr_employee_document: google_drive_link invisible

### DIFF
--- a/hr_employee_document/views/hr_employee.xml
+++ b/hr_employee_document/views/hr_employee.xml
@@ -11,7 +11,9 @@
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="groups_id" eval="[(6, 0, [ref('hr.group_hr_user') ])]"/>
         <field name="arch" type="xml">
-            <field name="google_drive_link" position="replace"/>
+            <field name="google_drive_link" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
             <div name="button_box" position="inside">
                 <button class="oe_stat_button"
                     icon="fa-book"


### PR DESCRIPTION
Replacing google drive link in view by nothing, that is deleting, breaks the view inheritance.

-> Making it invisible instead.