### PR TITLE
[12.0][ADD] hr_holidays_reminder_manager

### DIFF
--- a/hr_holidays_reminder_manager/__init__.py
+++ b/hr_holidays_reminder_manager/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/hr_holidays_reminder_manager/__manifest__.py
+++ b/hr_holidays_reminder_manager/__manifest__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Hashbang (<https://hashbang.fr>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "HR Holidays Reminder Manager",
+    "summary": "Send reminder to HR manager by mail on Leave Requests "
+               "creation and send a notify to HR manager when leave "
+               "is approved.",
+    "version": "12.0.1.1.0",
+    "category": "Human Resources",
+    "website": "https://github.com/OCA/hr",
+    "author": (
+        "Odoo Community Association (OCA), Hashbang"
+    ),
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "hr_holidays_settings",
+    ],
+    "data": [
+        'data/mail_data.xml',
+        'views/res_config_settings_view.xml',
+        'views/hr_employee.xml',
+    ],
+}

--- a/hr_holidays_reminder_manager/data/mail_data.xml
+++ b/hr_holidays_reminder_manager/data/mail_data.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data noupdate="1">
+    <template id="message_reminder_hr_managers">
+      <section>
+        <div style="margin: 10px; padding: 10px;">
+          <h1>Reminder of employee's leave <t t-esc="object.employee_id.name"/></h1>
+          <hr />
+          <p>
+            <span>Hi,</span><br />
+            <span style="margin-top: 8px;">You have been assigned to the <t t-esc="model_description or 'document'"/> <t t-esc="object.name_get()[0][1]"/>.</span>
+          </p>
+          <p style="margin-top: 24px; margin-bottom: 16px;">
+            <a t-att-href="'/mail/view?model=%s&amp;res_id=%s' % (object._name, object.id)" style="background-color:#875A7B; padding: 10px; text-decoration: none; color: #fff; border-radius: 5px;">
+                View <t t-esc="model_description or 'document'"/>
+            </a>
+          </p>
+        </div>
+      </section>
+    </template>
+  </data>
+</odoo>

--- a/hr_holidays_reminder_manager/i18n/fr.po
+++ b/hr_holidays_reminder_manager/i18n/fr.po
@@ -1,0 +1,103 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* hr_holidays_reminder_manager
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-03-18 08:50+0000\n"
+"PO-Revision-Date: 2020-03-18 08:50+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_holidays_reminder_manager
+#: model_terms:ir.ui.view,arch_db:hr_holidays_reminder_manager.res_config_settings_view_form
+msgid "Choose a period"
+msgstr "Choisir une période"
+
+#. module: hr_holidays_reminder_manager
+#: model:ir.model,name:hr_holidays_reminder_manager.model_res_company
+msgid "Companies"
+msgstr "Sociétés"
+
+#. module: hr_holidays_reminder_manager
+#: model:ir.model,name:hr_holidays_reminder_manager.model_res_config_settings
+msgid "Config Settings"
+msgstr "Paramètres de config"
+
+#. module: hr_holidays_reminder_manager
+#: model:ir.model,name:hr_holidays_reminder_manager.model_hr_employee
+msgid "Employee"
+msgstr "Employé"
+
+#. module: hr_holidays_reminder_manager
+#: model_terms:ir.ui.view,arch_db:hr_holidays_reminder_manager.message_reminder_hr_managers
+msgid "Hi"
+msgstr "Bonjour"
+
+#. module: hr_holidays_reminder_manager
+#: model:ir.model.fields,field_description:hr_holidays_reminder_manager.field_hr_employee__hr_manager
+msgid "Is a HR Manager"
+msgstr "Est un responsable RH"
+
+#. module: hr_holidays_reminder_manager
+#: model:ir.model,name:hr_holidays_reminder_manager.model_hr_leave
+msgid "Leave"
+msgstr "Congé"
+
+#. module: hr_holidays_reminder_manager
+#: model:ir.model.fields,field_description:hr_holidays_reminder_manager.field_hr_leave__reminder_id
+msgid "Mail"
+msgstr "Courriel"
+
+#. module: hr_holidays_reminder_manager
+#: selection:res.company,leave_reminder_period:0
+msgid "One day"
+msgstr "Un jour"
+
+#. module: hr_holidays_reminder_manager
+#: selection:res.company,leave_reminder_period:0
+msgid "One week"
+msgstr "Une semaine"
+
+#. module: hr_holidays_reminder_manager
+#: model:ir.model.fields,field_description:hr_holidays_reminder_manager.field_res_company__leave_reminder_period
+#: model:ir.model.fields,field_description:hr_holidays_reminder_manager.field_res_config_settings__leave_reminder_period
+msgid "Period before notifying the HR manager"
+msgstr "Période avant notification pour le responsable RH"
+
+#. module: hr_holidays_reminder_manager
+#: model_terms:ir.ui.view,arch_db:hr_holidays_reminder_manager.message_reminder_hr_managers
+msgid "Reminder of employee's leave"
+msgstr "Rappel de congé pour l'employé"
+
+#. module: hr_holidays_reminder_manager
+#: selection:res.company,leave_reminder_period:0
+msgid "Three days"
+msgstr "Trois jours"
+
+#. module: hr_holidays_reminder_manager
+#: selection:res.company,leave_reminder_period:0
+msgid "Two days"
+msgstr "Deux jours"
+
+#. module: hr_holidays_reminder_manager
+#: selection:res.company,leave_reminder_period:0
+msgid "Two weeks"
+msgstr "Deux semaines"
+
+#. module: hr_holidays_reminder_manager
+#: model_terms:ir.ui.view,arch_db:hr_holidays_reminder_manager.message_reminder_hr_managers
+msgid "View"
+msgstr "Voir"
+
+#. module: hr_holidays_reminder_manager
+#: model_terms:ir.ui.view,arch_db:hr_holidays_reminder_manager.message_reminder_hr_managers
+msgid "You have been assigned to the"
+msgstr "Vous avez été assigné·e à "
+

--- a/hr_holidays_reminder_manager/models/__init__.py
+++ b/hr_holidays_reminder_manager/models/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_leave, hr_employee, res_company, res_config_settings

--- a/hr_holidays_reminder_manager/models/hr_employee.py
+++ b/hr_holidays_reminder_manager/models/hr_employee.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class HREmployee(models.Model):
+    _inherit = "hr.employee"
+
+    hr_manager = fields.Boolean(string="Is a HR Manager")

--- a/hr_holidays_reminder_manager/models/hr_leave.py
+++ b/hr_holidays_reminder_manager/models/hr_leave.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timedelta
+from odoo import api, models, fields
+
+
+class HRLeave(models.Model):
+    _inherit = "hr.leave"
+
+    reminder_id = fields.Many2one(string="Mail", comodel_name="mail.mail",)
+
+    @api.multi
+    def _get_hr_managers_to_notify(self):
+        """Defines the hr managers to notify."""
+        self.ensure_one()
+        managers = self.env["hr.employee"].search([["hr_manager", "=", True]])
+        return managers
+
+    @api.multi
+    def _get_body_mail(self, template):
+        view = self.env["ir.ui.view"].browse(
+            self.env["ir.model.data"].xmlid_to_res_id(template)
+        )
+        msg = False
+        for record in self:
+            model_description = (
+                self.env["ir.model"]._get(record._name).display_name
+            )
+            values = {
+                "object": record,
+                "model_description": model_description,
+            }
+            msg = view.render(values, engine="ir.qweb", minimal_qcontext=True)
+            msg = self.env["mail.thread"]._replace_local_links(msg)
+        return msg
+
+    @api.multi
+    def write(self, vals):
+        res = super().write(vals)
+        if self.first_approver_id and self.reminder_id:
+            if self.holiday_status_id.double_validation:
+                self.reminder_id.send()
+            else:
+                self.reminder_id.unlink()
+            self.reminder_id = False
+        return res
+
+    @api.model
+    def create(self, vals):
+        res = super().create(vals)
+        res._planning_reminder_hr()
+        return res
+
+    @api.multi
+    def _planning_reminder_hr(self):
+        """Input: res.user"""
+        self.ensure_one()
+        company = self.employee_id.company_id
+        managers = self._get_hr_managers_to_notify()
+        if not managers:
+            return True
+        applicant = self.employee_id
+        managers_email = [
+            manager.user_id.email
+            for manager in managers
+            if manager.user_id
+        ]
+        email_to = ", ".join(managers_email)
+        mail_values = {
+            "auto_delete": True,
+            "notification": True,
+            "mail_server_id": (
+                self.env["ir.mail_server"].sudo().search([], limit=1).id,
+            ),
+            "model": "hr.leave",
+            "res_id": self.id,
+            "scheduled_date": (
+                datetime.today()
+                + timedelta(days=company.leave_reminder_period)
+            ),
+            "reply_to": applicant.user_id.email,
+            "email_to": email_to,
+            "email_from": (
+                f"From {applicant.name}, <{applicant.user_id.email}>"
+            ),
+            "subject": f"Reminder leave request - {applicant.name}",
+            "body_html": self._get_body_mail(
+                template=(
+                    "hr_holidays_reminder_manager."
+                    "message_reminder_hr_managers"
+                ),
+            ),
+        }
+        self.reminder_id = self.env["mail.mail"].create(mail_values)
+        return True

--- a/hr_holidays_reminder_manager/models/res_company.py
+++ b/hr_holidays_reminder_manager/models/res_company.py
@@ -1,0 +1,17 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    PERIODS = [
+        (1, "One day"),
+        (2, "Two days"),
+        (3, "Three days"),
+        (7, "One week"),
+        (14, "Two weeks"),
+    ]
+
+    leave_reminder_period = fields.Selection(
+        PERIODS, string="Period before notifying the HR manager", default=1,
+    )

--- a/hr_holidays_reminder_manager/models/res_config_settings.py
+++ b/hr_holidays_reminder_manager/models/res_config_settings.py
@@ -1,0 +1,21 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    PERIODS = [
+        (1, "One day"),
+        (2, "Two days"),
+        (3, "Three days"),
+        (7, "One week"),
+        (14, "Two weeks"),
+    ]
+
+    leave_reminder_period = fields.Selection(
+        PERIODS,
+        related="company_id.leave_reminder_period",
+        readonly=False,
+        string="Period before notifying the HR manager",
+        default=1,
+    )

--- a/hr_holidays_reminder_manager/readme/CONFIGURE.rst
+++ b/hr_holidays_reminder_manager/readme/CONFIGURE.rst
@@ -1,0 +1,6 @@
+To configure this module, you need to:
+
+ #. Go to *Employees* select an employee with HR manager role and Check *Is a HR manager*.
+ #. Go to *Leaves > Configuration > Settings*.
+ #. Choose a *Period before notifying the HR manager*.
+ 

--- a/hr_holidays_reminder_manager/readme/CONTRIBUTION.rst
+++ b/hr_holidays_reminder_manager/readme/CONTRIBUTION.rst
@@ -1,0 +1,1 @@
+* Hashbang <contact@hashbang.fr>

--- a/hr_holidays_reminder_manager/readme/DESCRIPTION.rst
+++ b/hr_holidays_reminder_manager/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module sends holiday reminders to HR managers.

--- a/hr_holidays_reminder_manager/readme/USAGE.rst
+++ b/hr_holidays_reminder_manager/readme/USAGE.rst
@@ -1,0 +1,3 @@
+To use this module, you need to:
+* Go to *Leaves > My Leaves > Leaves Requests* and create a leave request to be approved.
+* A reminder is created to notify the HR manager.

--- a/hr_holidays_reminder_manager/views/hr_employee.xml
+++ b/hr_holidays_reminder_manager/views/hr_employee.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="hr_employee_view_form" model="ir.ui.view">
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_form"/>
+        <field name="arch" type="xml">
+          <xpath expr="//field[@name='coach_id']" position="after">
+              <field name="hr_manager" />
+          </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/hr_holidays_reminder_manager/views/res_config_settings_view.xml
+++ b/hr_holidays_reminder_manager/views/res_config_settings_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="hr_holidays_settings.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='hr_holidays']/div[hasclass('o_settings_container')]" position="inside">
+                <div class="o_setting_box">
+                  <field placeholder="Choose a period" name="leave_reminder_period"/>
+                  <label for="leave_reminder_period"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR add hr_holidays_reminder_manager module in `OCA/hr`.

This module :

- Add settings in leave config to choose a waiting period to send a reminder.
- Add a field in `Is a HR manager` in employee form.
- Prepare a reminder to the HR managers.

If the leave is approved, the reminder is send immediately to HR manager.