### PR TITLE
[12.0][FIX] fix hr_calendar_rest_time

### DIFF
--- a/hr_calendar_rest_time/models/resource_calendar.py
+++ b/hr_calendar_rest_time/models/resource_calendar.py
@@ -1,6 +1,9 @@
 # Copyright 2020 Creu Blanca
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from datetime import timedelta
+
+
 from odoo import api, models
 from odoo.tools.float_utils import float_round
 
@@ -8,6 +11,11 @@ from odoo.tools.float_utils import float_round
 class ResourceCalendar(models.Model):
 
     _inherit = 'resource.calendar'
+
+    def _get_work_hours(self, start, stop, meta):
+        return (stop - start - timedelta(hours=sum([
+            attendance.rest_time for attendance in meta
+        ]))).total_seconds() / 3600
 
     @api.onchange('attendance_ids')
     def _onchange_hours_per_day(self):

--- a/resource_hook/hooks.py
+++ b/resource_hook/hooks.py
@@ -1,4 +1,5 @@
 from odoo.addons.resource.models.resource_mixin import ResourceMixin, ROUNDING_FACTOR
+from odoo.addons.resource.models.resource import ResourceCalendar
 from datetime import timedelta
 from odoo.tools import float_utils
 from pytz import utc
@@ -9,6 +10,9 @@ def post_load_hook():
     if not hasattr(ResourceMixin, 'get_work_days_data_original'):
         ResourceMixin.get_work_days_data_original = \
             ResourceMixin.get_work_days_data
+    if not hasattr(ResourceCalendar, 'get_work_hours_count_original'):
+        ResourceCalendar.get_work_hours_count_original = \
+            ResourceCalendar.get_work_hours_count
 
     def __new_get_work_days_data(
             self, from_datetime, to_datetime, compute_leaves=True,
@@ -69,4 +73,33 @@ def post_load_hook():
             'hours': sum(day_hours.values()),
         }
 
+    def __new_get_work_hours_count(
+        self, start_dt, end_dt, compute_leaves=True, domain=None
+    ):
+        """
+            `compute_leaves` controls whether or not this method is taking into
+            account the global leaves.
+
+            `domain` controls the way leaves are recognized.
+            None means default value ('time_type', '=', 'leave')
+
+            Counts the number of work hours between two datetimes.
+        """
+        # Set timezone in UTC if no timezone is explicitly given
+        if not start_dt.tzinfo:
+            start_dt = start_dt.replace(tzinfo=utc)
+        if not end_dt.tzinfo:
+            end_dt = end_dt.replace(tzinfo=utc)
+
+        if compute_leaves:
+            intervals = self._work_intervals(start_dt, end_dt, domain=domain)
+        else:
+            intervals = self._attendance_intervals(start_dt, end_dt)
+
+        return sum(
+            self._get_work_hours(start, stop, meta)
+            for start, stop, meta in intervals
+        )
+
     ResourceMixin.get_work_days_data = __new_get_work_days_data
+    ResourceCalendar.get_work_hours_count = __new_get_work_hours_count

--- a/resource_hook/models/__init__.py
+++ b/resource_hook/models/__init__.py
@@ -1,1 +1,2 @@
+from . import resource_calendar
 from . import resource_mixin

--- a/resource_hook/models/resource_calendar.py
+++ b/resource_hook/models/resource_calendar.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ResourceCalendar(models.Model):
+    _inherit = 'resource.calendar'
+
+    def _get_work_hours(self, start, stop, meta):
+        """
+        This method now returns the hours between the two ends of the
+        interval. Extend this method if you want to alter the logic.
+        :param interval:
+        :return: float representing the time worked.
+        """
+        return (stop - start).total_seconds() / 3600


### PR DESCRIPTION
Function `get_work_hours_count` in `resource.calendar` also requires the hook in order to change how hours are computed in an interval. Needed when computing the hours of leaves.

@etobella @JordiBForgeFlow 