### PR TITLE
[10.0][FIX] hr_attendance_report_theoretical_time

### DIFF
--- a/hr_attendance_report_theoretical_time/__manifest__.py
+++ b/hr_attendance_report_theoretical_time/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Theoretical vs Attended Time Analysis",
-    "version": "10.0.2.0.0",
+    "version": "10.0.2.0.1",
     "category": "Human Resources",
     "website": "https://github.com/OCA/hr",
     "author": "Tecnativa, "

--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
@@ -51,7 +51,7 @@
 
     <record id="hr_attendance.menu_hr_attendance_report" model="ir.ui.menu">
         <field name="action"/>
-        <field name="groups_id" eval="[(4, ref('hr_attendance.group_hr_attendance_user'))]"/>
+        <field name="groups_id" eval="[(4, ref('hr_attendance.group_hr_attendance'))]"/>
     </record>
 
     <menuitem id="menu_hr_attendance_report"


### PR DESCRIPTION
To fix the issue of menu path 'Attendaces > Reports' not being visible
to 'Manual Attendance' group.