### PR TITLE
[12.0][FIX] resource_hook : hook function _get_work_hours in day_total

### DIFF
--- a/resource_hook/hooks.py
+++ b/resource_hook/hooks.py
@@ -42,7 +42,7 @@ def post_load_hook():
         )
         day_total = defaultdict(float)
         for start, stop, meta in intervals:
-            day_total[start.date()] += (stop - start).total_seconds() / 3600
+            day_total[start.date()] += self._get_work_hours(start, stop, meta)
 
         # actual hours per day
         if compute_leaves:


### PR DESCRIPTION
This module compute days mistake when I install 'hr_calendar_rest_time' and 'payroll'

Step to error
1. Config Working Schedule by rest time = 1 hour
![Selection_001](https://user-images.githubusercontent.com/20896369/79826148-26255c00-83c5-11ea-908a-f8b9ba511611.png)
2. Generate payslip in payroll
3. Number of Days will compute mistake (exclude rest time)
![Selection_002](https://user-images.githubusercontent.com/20896369/79826342-a5b32b00-83c5-11ea-9c0c-e0e2af3b12fd.png)

I think day_total should be compute function similar day_hours.