### PR TITLE
[10.0] cleanup gitignore, lib dir should not be ignored (used for javascript 3rd party libraries)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,31 +2,6 @@
 __pycache__/
 *.py[cod]
 
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-env/
-bin/
-build/
-develop-eggs/
-dist/
-eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
-*.egg
-.eggs
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
 # Unit test / coverage reports
 htmlcov/
 .tox/
@@ -41,8 +16,10 @@ coverage.xml
 # Pycharm
 .idea
 
-# Mr Developer
-.mr.developer.cfg
+# Visual Studio Code
+.vscode
+
+# Eclipse
 .project
 .pydevproject
 


### PR DESCRIPTION
Most entries are only useful if developing python extensions
or using buildout
I've added also .vscode to ignore