### PR TITLE
[13.0] .gitignore: add !static/lib/ as per oca rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/_build/
 # Backup files
 *~
 *.swp
+
+# OCA rules
+!static/lib/


### PR DESCRIPTION
as per https://github.com/OCA/maintainer-quality-tools/blob/master/sample_files/.gitignore

I've added:
```
# OCA rules
!static/lib/
```

to make possibile adding static/lib 3rd party js libraries