### PR TITLE
[FIX] hr_employee_calendar_planning: link leaves

### DIFF
--- a/hr_employee_calendar_planning/hooks.py
+++ b/hr_employee_calendar_planning/hooks.py
@@ -48,7 +48,7 @@ def post_init_hook(cr, registry, employees=None):
             calendar_mapping[calendar].append(
                 (lines[0].date_from, lines[0].date_to, new_calendar),
             )
-        for employee in employees:
+        for employee in employees.filtered('resource_calendar_id'):
             calendar_lines = []
             for data in calendar_mapping[employee.resource_calendar_id]:
                 calendar_lines.append((0, 0, {
@@ -56,5 +56,12 @@ def post_init_hook(cr, registry, employees=None):
                     'date_end': data[1],
                     'calendar_id': data[2].id,
                 }))
+            # Extract employee's existing leaves so they are passed to the new
+            # automatic calendar.
+            leaves = employee.resource_calendar_id.leave_ids.filtered(
+                lambda x: x.resource_id == employee.resource_id)
             employee.calendar_ids = calendar_lines
             employee.resource_calendar_id.active = False
+            # Now the automatic calendar has been created, so we link the
+            # leaves to that one so they count correctly.
+            leaves.write({'calendar_id': employee.resource_calendar_id.id})

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -45,6 +45,13 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
         cls.employee = cls.env['hr.employee'].create({
             'name': 'Test employee',
         })
+        cls.leave1 = cls.env['resource.calendar.leaves'].create({
+            'name': 'Test leave',
+            'calendar_id': cls.calendar1.id,
+            'resource_id': cls.employee.resource_id.id,
+            'date_from': '2019-06-01',
+            'date_to': '2019-06-10',
+        })
 
     def test_calendar_planning(self):
         self.employee.calendar_ids = [
@@ -98,6 +105,10 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
         self.assertEqual(len(self.employee.calendar_ids), 1)
         self.assertFalse(self.employee.calendar_ids.date_start)
         self.assertFalse(self.employee.calendar_ids.date_end)
+        # Check that the employee leaves are transferred to the new calendar
+        self.assertFalse(self.calendar1.leave_ids)
+        self.assertEqual(
+            self.employee.resource_calendar_id.leave_ids, self.leave1)
 
     def test_post_install_hook_several_calendaries(self):
         self.calendar1.attendance_ids[0].date_from = '2019-01-01'


### PR DESCRIPTION
Forward port of https://github.com/OCA/hr/commit/19353e9d37b1044e60fc2cec8bc9e8b98c5a5022

- On the module init, existing employee calendar leaves should be linked
to the employee's new autocalendar.

cc @Tecnativa TT24299