### PR TITLE
[FIX] hr_employee_service_contract: _compute when dates changed

### DIFF
--- a/hr_employee_service_contract/models/hr_employee.py
+++ b/hr_employee_service_contract/models/hr_employee.py
@@ -31,7 +31,7 @@ class HrEmployee(models.Model):
     )
 
     @api.multi
-    @api.depends('contract_ids')
+    @api.depends('contract_ids', 'contract_ids.date_start')
     def _compute_first_contract_id(self):
         Contract = self.env['hr.contract']
         for employee in self:
@@ -42,7 +42,7 @@ class HrEmployee(models.Model):
             )
 
     @api.multi
-    @api.depends('contract_ids')
+    @api.depends('contract_ids', 'contract_ids.date_end')
     def _compute_last_contract_id(self):
         Contract = self.env['hr.contract']
         for employee in self:


### PR DESCRIPTION
Last contract should also be computed when `date_end` field is modified, not only when a contract is created or unlinked.

@alexey-pelykh @Saran440 @etobella

(edit) Same happens with first contract 