### PR TITLE
[FIX] hr_period: Error in onchange is fixed.

### DIFF
--- a/hr_period/models/hr_period.py
+++ b/hr_period/models/hr_period.py
@@ -81,6 +81,8 @@ class HrPeriod(models.Model):
         domain=[('hr_period', '=', True)],
         default=_default_type
     )
+    parent_id = fields.Many2one(
+        comodel_name='hr.period', string="Parent", index=1)
 
     @api.model
     def get_next_period(self, company_id, schedule_pay):


### PR DESCRIPTION
Hr.period inherit from date.range model from server-tools, and, in
date_range is added an onchange to assign a possible parent when update
dates, type, or company. But an error is returned when trying to assign the
search result because try to assign:

`date.range = hr.period`

To avoid this, now the field parent_id is assigned in hr_period, and
with this avoids the error.

Fixes https://github.com/OCA/hr/issues/882