### PR TITLE
[10.0][FIX] hr_holidays_compute_days: fix issues with timezone

### DIFF
--- a/hr_holidays_compute_days/README.rst
+++ b/hr_holidays_compute_days/README.rst
@@ -23,7 +23,7 @@ Employee Compute Leave Days
     :target: https://runbot.odoo-community.org/runbot/116/10.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 Computes the actual days for which employee will be on leave taking into
 account:
@@ -99,6 +99,10 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * Pedro M. Baeza
+
+* `Acsone <https://https://www.acsone.eu/>`__:
+
+  * Régis Pirard <regis.pirard@acsone.eu>
 
 Maintainers
 ~~~~~~~~~~~

--- a/hr_holidays_compute_days/models/hr_employee.py
+++ b/hr_holidays_compute_days/models/hr_employee.py
@@ -30,12 +30,16 @@ class HrEmployee(models.Model):
             for line in lines:
                 date = fields.Datetime.from_string(line.date)
                 tz_info = fields.Datetime.context_timestamp(self, date).tzinfo
-                working_start_date = date.replace(hour=0, minute=0, second=0, microsecond=0)
+                working_start_date = date.replace(
+                    hour=0, minute=0, second=0, microsecond=0
+                )
                 working_end_date = date.replace(
-                        hour=23, minute=59, second=59, microsecond=999999,
-                    )
-                working_start_date = working_start_date.replace(tzinfo=tz_info).astimezone(pytz.UTC).replace(tzinfo=None)
-                working_end_date = working_end_date.replace(tzinfo=tz_info).astimezone(pytz.UTC).replace(tzinfo=None)
+                    hour=23, minute=59, second=59, microsecond=999999,
+                )
+                working_start_date = working_start_date.replace(tzinfo=tz_info)\
+                    .astimezone(pytz.UTC).replace(tzinfo=None)
+                working_end_date = working_end_date.replace(tzinfo=tz_info)\
+                    .astimezone(pytz.UTC).replace(tzinfo=None)
                 leaves.append((
                     working_start_date,
                     working_end_date,

--- a/hr_holidays_compute_days/models/hr_employee.py
+++ b/hr_holidays_compute_days/models/hr_employee.py
@@ -77,4 +77,5 @@ class HrEmployee(models.Model):
             # We convert hours in days according to calendar "UOM" if present
             cal_uom = calendar.uom_id.factor or theoric_hours
             days_count += work_time.total_seconds() / 3600 / cal_uom
-        return round(days_count, 2)
+        # round to 4 decimals (as one minute is a 4 decimal day)
+        return round(days_count, 4)

--- a/hr_holidays_compute_days/models/hr_employee.py
+++ b/hr_holidays_compute_days/models/hr_employee.py
@@ -77,5 +77,5 @@ class HrEmployee(models.Model):
             # We convert hours in days according to calendar "UOM" if present
             cal_uom = calendar.uom_id.factor or theoric_hours
             days_count += work_time.total_seconds() / 3600 / cal_uom
-        # round to 4 decimals (as one minute is a 4 decimal day)
+        # round to be replaced by UOM minutes / seconds
         return round(days_count, 4)

--- a/hr_holidays_compute_days/models/hr_employee.py
+++ b/hr_holidays_compute_days/models/hr_employee.py
@@ -74,5 +74,7 @@ class HrEmployee(models.Model):
                 (interval[1] - interval[0] for interval in day_intervals),
                 timedelta(),
             )
-            days_count += work_time.total_seconds() / 3600 / theoric_hours
+            # We convert hours in days according to calendar "UOM" if present
+            cal_uom = calendar.uom_id.factor or theoric_hours
+            days_count += work_time.total_seconds() / 3600 / cal_uom
         return round(days_count, 2)

--- a/hr_holidays_compute_days/models/hr_employee.py
+++ b/hr_holidays_compute_days/models/hr_employee.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from dateutil import rrule
 from odoo import fields, models
 from odoo.tools.float_utils import float_is_zero
+import pytz
 
 
 class HrEmployee(models.Model):
@@ -28,12 +29,18 @@ class HrEmployee(models.Model):
             )
             for line in lines:
                 date = fields.Datetime.from_string(line.date)
-                leaves.append((
-                    date.replace(hour=0, minute=0, second=0, microsecond=0),
-                    date.replace(
+                tz_info = fields.Datetime.context_timestamp(self, date).tzinfo
+                working_start_date = date.replace(hour=0, minute=0, second=0, microsecond=0)
+                working_end_date = date.replace(
                         hour=23, minute=59, second=59, microsecond=999999,
-                    ),
+                    )
+                working_start_date = working_start_date.replace(tzinfo=tz_info).astimezone(pytz.UTC).replace(tzinfo=None)
+                working_end_date = working_end_date.replace(tzinfo=tz_info).astimezone(pytz.UTC).replace(tzinfo=None)
+                leaves.append((
+                    working_start_date,
+                    working_end_date,
                 ))
+
         return leaves
 
     def get_work_days_count(self, from_datetime, to_datetime, calendar=None):

--- a/hr_holidays_compute_days/models/hr_holidays.py
+++ b/hr_holidays_compute_days/models/hr_holidays.py
@@ -159,5 +159,4 @@ class HrHolidays(models.Model):
             days = employee.get_work_days_count(
                 from_datetime=date_from, to_datetime=date_to,
             )
-            if days:
-                self.number_of_days_temp = days
+            self.number_of_days_temp = days or 0

--- a/hr_holidays_compute_days/models/hr_holidays.py
+++ b/hr_holidays_compute_days/models/hr_holidays.py
@@ -161,3 +161,5 @@ class HrHolidays(models.Model):
             )
             if days:
                 self.number_of_days_temp = days
+
+

--- a/hr_holidays_compute_days/models/hr_holidays.py
+++ b/hr_holidays_compute_days/models/hr_holidays.py
@@ -148,6 +148,10 @@ class HrHolidays(models.Model):
         if self.date_to and self.date_from and self.date_from <= self.date_to:
             date_from = fields.Datetime.from_string(self.date_from)
             date_to = fields.Datetime.from_string(self.date_to)
+            # The current user might not be linked to an employee
+            # Odoo will handle the error when saving
+            if not self.employee_id:
+                return
             employee = self.employee_id
             if (self.holiday_status_id.exclude_public_holidays or
                     not self.holiday_status_id):

--- a/hr_holidays_compute_days/models/hr_holidays.py
+++ b/hr_holidays_compute_days/models/hr_holidays.py
@@ -161,5 +161,3 @@ class HrHolidays(models.Model):
             )
             if days:
                 self.number_of_days_temp = days
-
-

--- a/hr_holidays_compute_days/models/hr_holidays.py
+++ b/hr_holidays_compute_days/models/hr_holidays.py
@@ -100,24 +100,26 @@ class HrHolidays(models.Model):
         as fallback.
         """
         for record in self.filtered('from_full_day'):
-            tz_name = record.employee_id.user_id.tz or record.env.user.tz
-            dt = fields.Datetime.from_string(record.date_from_full).replace(
-                hour=0, minute=0, second=0, microsecond=0,
-                tzinfo=tz.gettz(tz_name),
-            ).astimezone(tz.tzutc())
-            record.date_from = fields.Datetime.to_string(dt)
+            if record.date_from_full:
+                tz_name = record.employee_id.user_id.tz or record.env.user.tz
+                dt = fields.Datetime.from_string(record.date_from_full).replace(
+                    hour=0, minute=0, second=0, microsecond=0,
+                    tzinfo=tz.gettz(tz_name),
+                ).astimezone(tz.tzutc())
+                record.date_from = fields.Datetime.to_string(dt)
 
     def _inverse_date_to_full(self):
         """Put end of the day in employee's user timezone, or user timezone
         as fallback.
         """
         for record in self.filtered('to_full_day'):
-            tz_name = record.employee_id.user_id.tz or record.env.user.tz
-            dt = fields.Datetime.from_string(record.date_to_full).replace(
-                hour=23, minute=59, second=59, microsecond=999999,
-                tzinfo=tz.gettz(tz_name),
-            ).astimezone(tz.tzutc())
-            record.date_to = fields.Datetime.to_string(dt)
+            if record.date_to_full:
+                tz_name = record.employee_id.user_id.tz or record.env.user.tz
+                dt = fields.Datetime.from_string(record.date_to_full).replace(
+                    hour=23, minute=59, second=59, microsecond=999999,
+                    tzinfo=tz.gettz(tz_name),
+                ).astimezone(tz.tzutc())
+                record.date_to = fields.Datetime.to_string(dt)
 
     @api.onchange('date_from_full', 'from_full_day')
     def _onchange_date_from_full(self):

--- a/hr_holidays_compute_days/models/resource_calendar.py
+++ b/hr_holidays_compute_days/models/resource_calendar.py
@@ -8,14 +8,6 @@ from dateutil import rrule
 import pytz
 
 
-def to_naive_user_tz(datetime, record):
-    tz_name = record.env.context.get('tz') or record.env.user.tz
-    tz = tz_name and pytz.timezone(tz_name) or pytz.UTC
-    return pytz.UTC.localize(
-        datetime.replace(tzinfo=None), is_dst=False,
-    ).astimezone(tz).replace(tzinfo=None)
-
-
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'
 
@@ -30,8 +22,6 @@ class ResourceCalendar(models.Model):
         """ Lists the current resource's work intervals between the two
         provided datetimes (inclusive) expressed in UTC, for each worked day.
         """
-        start_dt = to_naive_user_tz(start_dt, self.env.user)
-        end_dt = to_naive_user_tz(end_dt, self.env.user)
         real_weekdays = self._get_weekdays()
         if self.env.context.get('include_rest_days'):
             full_weekdays = range(7)

--- a/hr_holidays_compute_days/models/resource_calendar.py
+++ b/hr_holidays_compute_days/models/resource_calendar.py
@@ -5,7 +5,6 @@
 
 from odoo import models
 from dateutil import rrule
-import pytz
 
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'

--- a/hr_holidays_compute_days/models/resource_calendar.py
+++ b/hr_holidays_compute_days/models/resource_calendar.py
@@ -6,6 +6,7 @@
 from odoo import models
 from dateutil import rrule
 
+
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'
 
@@ -25,8 +26,8 @@ class ResourceCalendar(models.Model):
             full_weekdays = range(7)
         else:
             full_weekdays = real_weekdays
-        for day in rrule.rrule(rrule.DAILY, dtstart=start_dt.date(), until=end_dt.date(),
-                               byweekday=full_weekdays):
+        for day in rrule.rrule(rrule.DAILY, dtstart=start_dt.date(),
+                               until=end_dt.date(), byweekday=full_weekdays):
             start_date = (
                 start_dt if day.date() == start_dt.date() else day.replace(
                     hour=0, minute=0, second=0, microsecond=0,

--- a/hr_holidays_compute_days/models/resource_calendar.py
+++ b/hr_holidays_compute_days/models/resource_calendar.py
@@ -28,6 +28,8 @@ class ResourceCalendar(models.Model):
             full_weekdays = real_weekdays
         for day in rrule.rrule(rrule.DAILY, dtstart=start_dt.date(),
                                until=end_dt.date(), byweekday=full_weekdays):
+            # get_working_intervals_of_day can only accept interval of one day
+            # the following intends to split it in two intervals
             start_date = (
                 start_dt if day.date() == start_dt.date() else day.replace(
                     hour=0, minute=0, second=0, microsecond=0,

--- a/hr_holidays_compute_days/models/resource_calendar.py
+++ b/hr_holidays_compute_days/models/resource_calendar.py
@@ -7,7 +7,6 @@ from odoo import models
 from dateutil import rrule
 import pytz
 
-
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'
 
@@ -27,7 +26,7 @@ class ResourceCalendar(models.Model):
             full_weekdays = range(7)
         else:
             full_weekdays = real_weekdays
-        for day in rrule.rrule(rrule.DAILY, dtstart=start_dt, until=end_dt,
+        for day in rrule.rrule(rrule.DAILY, dtstart=start_dt.date(), until=end_dt.date(),
                                byweekday=full_weekdays):
             start_date = (
                 start_dt if day.date() == start_dt.date() else day.replace(

--- a/hr_holidays_compute_days/tests/test_holidays_compute_days.py
+++ b/hr_holidays_compute_days/tests/test_holidays_compute_days.py
@@ -133,7 +133,13 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
             'exclude_rest_days': True,
             'compute_full_days': False,
         })
-
+        # In Odoo, date values are always displayed to the user according to the BROWSER timezone
+        # While on the other hand many parts of the code does convert dates according to
+        # user's preference (cls.env.user.tz)
+        # A mismatch between browser's and user's timezone lead to wrong behavior
+        # See also https://github.com/odoo/odoo/issues/28518
+        # Here we set timezone to 'GB' (corresponding to browser's timezone in unit-test mode)
+        cls.env.user.tz = 'GB'
 
 class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
     def test_onchange_dates(self):
@@ -234,7 +240,7 @@ class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
             'employee_id': self.employee_1.id,
         })
         holidays._onchange_data_hr_holidays_compute_days()
-        self.assertEqual(holidays.number_of_days_temp, 0.375)
+        self.assertEqual(holidays.number_of_days_temp, 0.25)
 
     def test_fractional_number_days_1H(self):
         holidays = self.HrHolidays.new({

--- a/hr_holidays_compute_days/tests/test_holidays_compute_days.py
+++ b/hr_holidays_compute_days/tests/test_holidays_compute_days.py
@@ -36,7 +36,7 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
         cls.calendar_FTE_80 = cls.env['resource.calendar'].create({
             'name': 'Calendar FTE 80/100',
         })
-        for day in ['1','2','3']:  # From Tuesday to Thursday (8H)
+        for day in ['1', '2', '3']:  # From Tuesday to Thursday (8H)
             cls.calendar_FTE_80.attendance_ids = [
                 (0, 0, {
                     'name': 'Attendance',
@@ -133,13 +133,15 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
             'exclude_rest_days': True,
             'compute_full_days': False,
         })
-        # In Odoo, date values are always displayed to the user according to the BROWSER timezone
-        # While on the other hand many parts of the code does convert dates according to
-        # user's preference (cls.env.user.tz)
+        # Date values are always displayed according to the BROWSER timezone
+        # While on the other hand many parts of the code does convert dates according
+        # to user's preference (cls.env.user.tz)
         # A mismatch between browser's and user's timezone lead to wrong behavior
         # See also https://github.com/odoo/odoo/issues/28518
-        # Here we set timezone to 'GB' (corresponding to browser's timezone in unit-test mode)
+        # Here we set timezone to 'GB' (corresponding to browser's
+        # timezone in unit-test mode)
         cls.env.user.tz = 'GB'
+
 
 class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
     def test_onchange_dates(self):

--- a/hr_holidays_compute_days/tests/test_holidays_compute_days.py
+++ b/hr_holidays_compute_days/tests/test_holidays_compute_days.py
@@ -32,6 +32,34 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
                     'hour_to': '18',
                 }),
             ]
+        # Calendar for an FTE of 80/100 with presence Monday and Friday AM only
+        cls.calendar_FTE_80 = cls.env['resource.calendar'].create({
+            'name': 'Calendar FTE 80/100',
+        })
+        for day in ['1','2','3']:  # From Tuesday to Thursday (8H)
+            cls.calendar_FTE_80.attendance_ids = [
+                (0, 0, {
+                    'name': 'Attendance',
+                    'dayofweek': str(day),
+                    'hour_from': '08',
+                    'hour_to': '12',
+                }),
+                (0, 0, {
+                    'name': 'Attendance All Day',
+                    'dayofweek': str(day),
+                    'hour_from': '14',
+                    'hour_to': '18',
+                }),
+            ]
+        for day in ['0', '4']:  # monday to wednesday (4H)
+            cls.calendar_FTE_80.attendance_ids = [
+                (0, 0, {
+                    'name': 'Attendance AM only',
+                    'dayofweek': str(day),
+                    'hour_from': '08',
+                    'hour_to': '12',
+                }),
+            ]
         cls.address_1 = cls.env['res.partner'].create({
             'name': 'Address 1',
             'country_id': cls.env.ref('base.uk').id,
@@ -40,6 +68,10 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
             'name': 'Address 1',
             'country_id': cls.env.ref('base.es').id,
             'state_id': cls.env.ref('base.state_es_cr').id,
+        })
+        cls.address_be = cls.env['res.partner'].create({
+            'name': 'Address (Belgium)',
+            'country_id': cls.env.ref('base.be').id,
         })
         cls.employee_1 = cls.env['hr.employee'].create({
             'name': 'Employee 1',
@@ -50,6 +82,11 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
             'name': 'Employee 2',
             'calendar_id': cls.calendar.id,
             'address_id': cls.address_2.id,
+        })
+        cls.employee_be = cls.env['hr.employee'].create({
+            'name': 'Employee (Belgium)',
+            'calendar_id': cls.calendar_FTE_80.id,
+            'address_id': cls.address_be.id,
         })
         # Use a very old year for avoiding to collapse with current data
         cls.public_holiday_global = cls.HrHolidaysPublic.create({
@@ -88,6 +125,12 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
             'name': 'Leave Type Test Without excludes',
             'exclude_public_holidays': False,
             'exclude_rest_days': False,
+            'compute_full_days': False,
+        })
+        cls.holiday_type_hours = cls.env['hr.holidays.status'].create({
+            'name': 'Leave Type Test',
+            'exclude_public_holidays': True,
+            'exclude_rest_days': True,
             'compute_full_days': False,
         })
 
@@ -163,3 +206,66 @@ class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
         holidays._onchange_data_hr_holidays_compute_days()
         self.assertEqual(holidays.number_of_days_temp, 0.5)
 
+    def test_fractional_number_days_time_off(self):
+        holidays = self.HrHolidays.new({
+            'date_from': '1946-12-24 07:00:00',
+            'date_to': '1946-12-24 08:00:00',
+            'holiday_status_id': self.holiday_type_hours,
+            'employee_id': self.employee_be.id,
+        })
+        holidays._onchange_data_hr_holidays_compute_days()
+        self.assertEqual(holidays.number_of_days_temp, 0)
+
+    def test_fractional_number_days_am(self):
+        holidays = self.HrHolidays.new({
+            'date_from': '1946-12-23 08:00:00',
+            'date_to': '1946-12-23 14:00:00',
+            'holiday_status_id': self.holiday_type_hours,
+            'employee_id': self.employee_1.id,
+        })
+        holidays._onchange_data_hr_holidays_compute_days()
+        self.assertEqual(holidays.number_of_days_temp, 0.5)
+
+    def test_fractional_number_days_pm(self):
+        holidays = self.HrHolidays.new({
+            'date_from': '1946-12-23 12:00:00',
+            'date_to': '1946-12-23 16:00:00',
+            'holiday_status_id': self.holiday_type_hours,
+            'employee_id': self.employee_1.id,
+        })
+        holidays._onchange_data_hr_holidays_compute_days()
+        self.assertEqual(holidays.number_of_days_temp, 0.375)
+
+    def test_fractional_number_days_1H(self):
+        holidays = self.HrHolidays.new({
+            'date_from': '1946-12-23 14:00:00',
+            'date_to': '1946-12-23 15:00:00',
+            'holiday_status_id': self.holiday_type_hours,
+            'employee_id': self.employee_1.id,
+        })
+        holidays._onchange_data_hr_holidays_compute_days()
+        self.assertEqual(holidays.number_of_days_temp, 0.125)
+
+    def test_fractional_number_days_35MIN(self):
+        holidays = self.HrHolidays.new({
+            'date_from': '1946-12-23 15:00:00',
+            'date_to': '1946-12-23 15:35:00',
+            'holiday_status_id': self.holiday_type_hours,
+            'employee_id': self.employee_1.id,
+        })
+        holidays._onchange_data_hr_holidays_compute_days()
+        self.assertEqual(holidays.number_of_days_temp, 0.0729)
+
+    # Employee with 80% FTE (monday/friday AM only), one public day 25/12 (Wednesday)
+    # From 23/12 08:00 to 31/12 10:00
+    # Holiday type compute full days = False
+    # Should compute 0.5 + 1 + 0 + 1 + 0.5 + 0 + 0 + 0.5 + 0.25 =   3.75
+    def test_fractional_number_days_FTE_80(self):
+        holidays = self.HrHolidays.new({
+            'date_from': '1946-12-23 08:00:00',
+            'date_to': '1946-12-31 10:00:00',
+            'holiday_status_id': self.holiday_type_hours,
+            'employee_id': self.employee_be.id,
+        })
+        holidays._onchange_data_hr_holidays_compute_days()
+        self.assertEqual(holidays.number_of_days_temp, 3.75)

--- a/hr_holidays_compute_days/tests/test_holidays_compute_days.py
+++ b/hr_holidays_compute_days/tests/test_holidays_compute_days.py
@@ -90,8 +90,6 @@ class TestHolidaysComputeDaysBase(common.SavepointCase):
             'exclude_rest_days': False,
             'compute_full_days': False,
         })
-        # Remove timezone for controlling data better
-        cls.env.user.tz = False
 
 
 class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
@@ -164,3 +162,4 @@ class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
         })
         holidays._onchange_data_hr_holidays_compute_days()
         self.assertEqual(holidays.number_of_days_temp, 0.5)
+


### PR DESCRIPTION
**A - When creating a leave - Error with timezone**

I have an issue with hr_holidays_compute_days, related to the timezone handling.

Steps to reproduce : 

1) Create a new leave type "TEST" with parameters :

- exclude_rest_days = True
- exclude_public_holidays = True
- compute_full_days = False

2) Check that employee Pieter Parker has the default calendar (40 Hours/Week) which is configured everyday with

- 08h00 / 12h00
- 13h00 / 17h00

3) Create a leave request with

- Employee = Pieter Parker
- Leave type = TEST
- Period = select a working day with no leave and choose from 8h00 to 17h00

7 hours are computed (instead of 8 hours).

If you set the leave from 7h00 to 16h00, 8 hours are computed.

![OCA - hr_holidays_compute_days](https://user-images.githubusercontent.com/61087258/94134106-de1dd000-fe61-11ea-9831-11ec16b7b5c2.PNG)


![OCA - hr_holidays_compute_days v2](https://user-images.githubusercontent.com/61087258/94134129-e249ed80-fe61-11ea-8020-00554d94cd49.PNG)


@lmignon found it was due to the function to_naive_user_tz which transform start_dt and end_dt to user's timezone.
Theses transformed hours are then mishandled by get_working_intervals_of_day.

Solution:

- remove function to_naive_user_tz 
- pass date instead of datetime in "rrule.rrule(rrule.DAILY, dtstart=start_dt.date(),until=end_dt.date(), byweekday=full_weekdays):" or the last day of the period is never taken into account when "full day" is checked.


**B- When creating a leave - Error when user is not linked to employee**

When the user is not linked to an employee, get_work_days_count produce an error when executing self.ensure_one() (as there is no hr.employee).


**C- When creating a leave - Error when you check option full days but have not yet defined a datetime**

  File "/home/rpi/odoo-lns/hr/hr_holidays_compute_days/models/hr_holidays.py", line 125, in _onchange_date_from_full
    self._inverse_date_from_full()
  File "/home/rpi/odoo-lns/hr/hr_holidays_compute_days/models/hr_holidays.py", line 104, in _inverse_date_from_full
    dt = fields.Datetime.from_string(record.date_from_full).replace(
AttributeError: 'NoneType' object has no attribute 'replace' 

**D- When creating a leave - if I select a rest day, 1 day is computed**
(the leave is configured with exclude_rest_days = True)
This is due to _iter_work_intervals.

When a rest day is selected, this part does nothing as there is no day in the interval :

"        for day in rrule.rrule(rrule.DAILY, dtstart=start_dt.date(),
                               until=end_dt.date(), byweekday=full_weekdays):"

then get_work_days_count returns 0

then _onchange_data_hr_holidays_compute_days does nothing

Solution : self.number_of_days_temp must bu set to 0 when there is no "days".

**E- When creating a leave - if I choose half-time day, 1 day is computed**
To reproduce : assign a calendar with only 8:00 to 12:00 the friday.
Create a leave request Friday from 8 to 17 (or full day) => one day is computed.
The day is relative to the period in the calendar (ie : a leave from 8:00 to 10:00 will count as half-day).

Note : somehow this is not the case when the other OCA module "hr_holidays_hour" is installed.
As leaves are computed in hours, we do not have to compute their equivalent in days.

This is due to function get_work_days_count in hr_employee which does the following :

days_count += work_time.total_seconds() / 3600 / theoric_hours

By dividing by "theoric_hours", we will always compute one day when the period of the leave equals the period in the calendar.

This leads to redefinition of what is one day of leave and how many days of leaves I might have.
My point is that : 

* "one day of leave" should be relative to the full time equivalent in the company (for example if a full-time equivalent works 40 hours per week, meaning 8 hours a day, then 4 hours of leave should count as 4h/8h = 0,5 days

* Leave attribution should always be expressed in full time equivalent. So in my example, a full-time employee will have an attribution of 20 days, while a 50% part-time employee will have a 10 days attribution.

I will align on standard Odoo function which deals this with calendar UOM: 

"resource.calendar"

    uom_id = fields.Many2one("product.uom", string="Hours per Day", required=True,
        default=lambda self: self.env.ref('product.product_uom_hour'),
        help="""Average hours of work per day.
                It is used in an employee leave request to compute the number of days consumed based on the resource calendar.
                It can be used to handle various contract types, e.g.:
                - 38 Hours/Week, 5 Days/Week: 1 Day = 7.6 Hours
                - 45 Hours/Week, 5 Days/Week: 1 Day = 9.0 Hours""")


**F- computation is incorrect when your leave is near a public leave and your timezone is GMT+X**

My test is : 
San Fransisco timezone (! browser sensor ! + Odoo préférences)
Public holiday 07/10/2020
06/10/2020 17:00:00 to = 06/10/2020 17:00:00
it computes 1 day instead of 0 

This is because the date interval, which is converted to UTC, come across the Public Holiday interval which is not converted to UTC.

Fix : Convert public leaves to UTC according to user's timezone
