### PR TITLE
[FIX] hr_expense_advance_clearing: analytic account visibility

### DIFF
--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -37,6 +37,9 @@
             <h1 position="after">
                 <field name="advance"/><label for="advance"/>
             </h1>
+            <field name="analytic_account_id" position="attributes">
+                <attribute name="attrs">{'invisible': [('advance', '!=', False)]}</attribute>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
We should prevent setting the analytic account in expenses used as
employees advance. Otherwise, it can lead to errors charging against an
analytic account that later won't be compensated when all is reconcile.
Anyway, the advance is not an expense, but money of the company moving
from one place to another, that later will be used for real expenses
that will be imputed to the corresponding analytic account

cc @Tecnativa TT25442