### PR TITLE
[FIX] add missing parameter to unlink() method of calendar.event

### DIFF
--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -237,5 +237,5 @@ class HrHolidaysPublicLine(models.Model):
 
     @api.multi
     def unlink(self):
-        self.mapped('meeting_id').unlink()
+        self.mapped('meeting_id').unlink(can_be_deleted=True)
         return super().unlink()


### PR DESCRIPTION
Added missing parameter **`can_be_deleted=True`** to `unlink()` method of  calendar.event model
[See comment here](https://github.com/OCA/hr/commit/c6e8a68544af66664db17513938db3fb77e6f9da#commitcomment-43578531)