### PR TITLE
[14.0][REF] hr_employee_firstname,hr_employee_lastnames: Removed partner-contact dependencies

### DIFF
--- a/hr_employee_firstname/__manifest__.py
+++ b/hr_employee_firstname/__manifest__.py
@@ -13,8 +13,8 @@
     "license": "AGPL-3",
     "category": "Human Resources",
     "summary": "Adds First Name to Employee",
-    "depends": ["hr", "partner_firstname"],
-    "data": ["views/hr_view.xml"],
+    "depends": ["hr"],
+    "data": ["views/hr_view.xml", "views/base_config_view.xml"],
     "post_init_hook": "post_init_hook",
     "installable": True,
 }

--- a/hr_employee_firstname/i18n/es.po
+++ b/hr_employee_firstname/i18n/es.po
@@ -25,6 +25,12 @@ msgid "Employee"
 msgstr "Empleado"
 
 #. module: hr_employee_firstname
+#: model_terms:ir.ui.view,arch_db:hr_employee_firstname.res_config_settings_view_form
+#: model:ir.model.fields,field_description:hr_employee_firstname.field_res_config_settings__employee_names_order
+msgid "Employee Names Order"
+msgstr "Orden de los Nombres de Empleados"
+
+#. module: hr_employee_firstname
 #: model:ir.model.fields,field_description:hr_employee_firstname.field_hr_employee__firstname
 msgid "First name"
 msgstr ""

--- a/hr_employee_firstname/models/__init__.py
+++ b/hr_employee_firstname/models/__init__.py
@@ -1,3 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
+from . import base_config_settings
 from . import hr_employee

--- a/hr_employee_firstname/models/base_config_settings.py
+++ b/hr_employee_firstname/models/base_config_settings.py
@@ -1,0 +1,31 @@
+# Copyright 2015 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    employee_names_order = fields.Selection(
+        string="Employee Names Order",
+        selection="_employee_names_order_selection",
+        help="Order to compose employee fullname",
+        config_parameter="employee_names_order",
+        default=lambda a: a._employee_names_order_default(),
+        required=True,
+    )
+
+    def _employee_names_order_selection(self):
+        return [
+            ("last_first", "Lastname Firstname"),
+            ("last_first_comma", "Lastname, Firstname"),
+            ("first_last", "Firstname Lastname"),
+        ]
+
+    def _employee_names_order_default(self):
+        return self.env["hr.employee"]._names_order_default()

--- a/hr_employee_firstname/tests/test_hr_employee_firstname.py
+++ b/hr_employee_firstname/tests/test_hr_employee_firstname.py
@@ -118,7 +118,7 @@ class TestEmployeeFirstname(TransactionCase):
 
     def test_lastname_firstname(self):
         self.env["ir.config_parameter"].sudo().set_param(
-            "partner_names_order", "last_first"
+            "employee_names_order", "last_first"
         )
 
         self.employee1_id.write({"name": "Carnaud-Eyck Jean-Pierre"})
@@ -152,3 +152,22 @@ class TestEmployeeFirstname(TransactionCase):
     def test_no_firstname_and_lastname(self):
         with self.assertRaises(ValidationError):
             self.employee1_id.write({"firstname": "", "lastname": ""})
+
+    def test_change_firstname_and_lastname_with_set_last_first_comma(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "employee_names_order", "last_first_comma"
+        )
+        self.employee1_id.write({"firstname": "Jean-Pierre", "lastname": "Carnaud"})
+        self.employee1_id.refresh()
+
+        self.assertEqual(self.employee1_id.name, "Carnaud, Jean-Pierre")
+
+    def test_change_name_with_space_with_set_last_first_comma(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "employee_names_order", "last_first_comma"
+        )
+        self.employee1_id.write({"name": "  Carnaud-Eyck,  Jean-Pierre"})
+        self.employee1_id.refresh()
+
+        self.assertEqual(self.employee1_id.firstname, "Jean-Pierre")
+        self.assertEqual(self.employee1_id.lastname, "Carnaud-Eyck")

--- a/hr_employee_firstname/views/base_config_view.xml
+++ b/hr_employee_firstname/views/base_config_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">Add employee_names_order config parameter</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='companies']" position='after'>
+                <h2>Employee Names Order</h2>
+                <div class="row mt16 o_settings_container" name="employee_names_order">
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_right_pane">
+                            <field name="employee_names_order" />
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/hr_employee_lastnames/__manifest__.py
+++ b/hr_employee_lastnames/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "category": "Human Resources",
     "summary": "Split Name in First Name, Father's Last Name and Mother's Last Name",
-    "depends": ["partner_second_lastname", "hr_employee_firstname"],
+    "depends": ["hr_employee_firstname"],
     "data": ["views/hr_views.xml"],
     "post_init_hook": "post_init_hook",
     "demo": [],

--- a/hr_employee_lastnames/hook.py
+++ b/hr_employee_lastnames/hook.py
@@ -26,4 +26,4 @@ def post_init_hook(cr, _):
     cr.execute("UPDATE hr_employee SET firstname = NULL, lastname = NULL")
     env = Environment(cr, SUPERUSER_ID, {})
     env["hr.employee"]._install_employee_lastnames()
-    env["ir.config_parameter"].sudo().set_param("partner_names_order", "first_last")
+    env["ir.config_parameter"].sudo().set_param("employee_names_order", "first_last")

--- a/hr_employee_lastnames/tests/test_hr_employee_lastnames.py
+++ b/hr_employee_lastnames/tests/test_hr_employee_lastnames.py
@@ -1,3 +1,4 @@
+from odoo import exceptions
 from odoo.tests.common import TransactionCase
 
 
@@ -5,7 +6,7 @@ class TestEmployeeLastnames(TransactionCase):
     def setUp(self):
         super(TestEmployeeLastnames, self).setUp()
         self.env["ir.config_parameter"].sudo().set_param(
-            "partner_names_order", "first_last"
+            "employee_names_order", "first_last"
         )
         self.employee_model = self.env["hr.employee"]
 
@@ -84,6 +85,13 @@ class TestEmployeeLastnames(TransactionCase):
         self.assertEqual(self.employee30_id.lastname, "JenssensFamke")
         self.assertEqual(self.employee30_id.lastname2, False)
 
+        employee_without_name = self.employee_model
+        with self.assertRaises(exceptions.ValidationError):
+            employee_without_name = self.employee_model.create(
+                {"firstname": "", "lastname": ""}
+            )
+        self.assertEqual(employee_without_name, self.employee_model)
+
     def test_change_name(self):
         self.employee1_id.write({"name": "Pedro Martinez Torres"})
         self.employee1_id.refresh()
@@ -117,3 +125,39 @@ class TestEmployeeLastnames(TransactionCase):
         self.employee1_id.refresh()
 
         self.assertEqual(self.employee1_id.name, "Jean-Pierre Fernandez Carnaud")
+
+    def test_change_lastname_with_set_last_first(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "employee_names_order", "last_first"
+        )
+        self.employee1_id.write({"lastname": "Lopez"})
+        self.employee1_id.refresh()
+
+        self.assertEqual(self.employee1_id.name, "Lopez Gonzalez Manuel")
+
+    def test_change_name_with_set_last_first(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "employee_names_order", "last_first"
+        )
+        self.employee1_id.write({"name": "Martinez Torres Pedro"})
+        self.employee1_id.refresh()
+
+        self.assertEqual(self.employee1_id.firstname, "Pedro")
+        self.assertEqual(self.employee1_id.lastname, "Martinez")
+        self.assertEqual(self.employee1_id.lastname2, "Torres")
+
+        self.employee1_id.write({"name": ""})
+        self.employee1_id.refresh()
+
+        self.assertEqual(self.employee1_id.firstname, "Pedro")
+        self.assertEqual(self.employee1_id.lastname, "Martinez")
+        self.assertEqual(self.employee1_id.lastname2, "Torres")
+
+    def test_change_lastname_with_set_last_first_comma(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "employee_names_order", "last_first_comma"
+        )
+        self.employee1_id.write({"lastname": "Lopez"})
+        self.employee1_id.refresh()
+
+        self.assertEqual(self.employee1_id.name, "Lopez Gonzalez, Manuel")


### PR DESCRIPTION
This change makes the module work without the need to install the functionalities in partner, making the process independent of the [partner-contact](https://github.com/OCA/partner-contact/tree/14.0) modules ([partner_fistname](https://github.com/OCA/partner-contact/tree/14.0/partner_firstname) and [partner_second_lastname](https://github.com/OCA/partner-contact/tree/14.0/partner_second_lastname) respectively)

Demostrative Video:  https://drive.google.com/file/d/1Rllj1pKQwxC6J4hJdHTXgB4pzw3AA2fM/view
