### PR TITLE
Update URL for Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Runbot Status](https://runbot.odoo-community.org/runbot/badge/flat/116/12.0.svg)](https://runbot.odoo-community.org/runbot/repo/github-com-oca-hr-116)
-[![Build Status](https://travis-ci.org/OCA/hr.svg?branch=12.0)](https://travis-ci.org/OCA/hr)
+[![Build Status](https://travis-ci.com/OCA/hr.svg?branch=12.0)](https://travis-ci.com/OCA/hr)
 [![codecov](https://codecov.io/gh/OCA/hr/branch/12.0/graph/badge.svg)](https://codecov.io/gh/OCA/hr)
 
 Human Resources


### PR DESCRIPTION
CI was migrated from travis-ci.org to travis-ci.com