### PR TITLE
[12.0][FIX] hr_employee_calendar_planning: generate when needed

### DIFF
--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -14,6 +14,8 @@ class ResourceCalendar(models.Model):
     @api.multi
     def write(self, vals):
         res = super(ResourceCalendar, self).write(vals)
+        if 'attendance_ids' not in vals:
+            return res
         for record in self.filtered('active'):
             calendars = self.env['hr.employee.calendar'].search([
                 ('calendar_id', '=', record.id)


### PR DESCRIPTION
Underlying calendars should only be regenerated if some attendance changes on a parent calendar. Now they are getting regenerated everytime something changes in the `resource.calendar`, which I think it's not necessary.

@pedrobaeza @etobella @Saran440 