### PR TITLE
[ADD] hr_holidays_public: create resource calendar leaves wizard

### DIFF
--- a/hr_holidays_public/__manifest__.py
+++ b/hr_holidays_public/__manifest__.py
@@ -22,6 +22,7 @@
         'views/hr_holidays_public_view.xml',
         'views/hr_leave_type.xml',
         'wizards/holidays_public_next_year_wizard.xml',
+        'wizards/resource_calendar_leaves_wizard.xml',
     ],
     'installable': True,
 }

--- a/hr_holidays_public/wizards/__init__.py
+++ b/hr_holidays_public/wizards/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import holidays_public_next_year_wizard
+from . import resource_calendar_leaves_wizard

--- a/hr_holidays_public/wizards/resource_calendar_leaves_wizard.py
+++ b/hr_holidays_public/wizards/resource_calendar_leaves_wizard.py
@@ -1,0 +1,52 @@
+from datetime import datetime, time
+from pytz import timezone, utc
+
+from odoo import api, models, fields
+
+
+class ResourceCalendarLeavesWizard(models.TransientModel):
+    _name = 'public.holidays.resource.calendar.leaves.wizard'
+    _description = 'Generate Resource Leaves from Public Holidays'
+
+    def _default_holidays_id(self):
+        return self.env['hr.holidays.public'].search([
+            ('year', '=', datetime.today().year)])
+
+    calendar_id = fields.Many2one(
+        comodel_name='resource.calendar',
+        string='Calendar',
+        required=True)
+    holidays_id = fields.Many2one(
+        comodel_name='hr.holidays.public',
+        string='Holidays',
+        default=_default_holidays_id,
+        required=True)
+    replace = fields.Boolean(
+        string='Replace Current',
+        help='Replace existing global leaves on resource.',
+        default=True)
+
+    @api.multi
+    def create_leaves(self):
+        self.ensure_one()
+        leaves = []
+        tz = timezone(self.calendar_id.tz)
+        for line in self.holidays_id.line_ids:
+            dt_from = tz.localize(datetime.combine(line.date, time.min))
+            dt_to = tz.localize(datetime.combine(line.date, time.max))
+            leaves.append({
+                'name': line.name,
+                'date_from': dt_from.astimezone(utc),
+                'date_to': dt_to.astimezone(utc),
+            })
+        if self.replace:
+            self.calendar_id.global_leave_ids.unlink()
+        self.calendar_id.write({
+            'leave_ids': [(0, 0, leave) for leave in leaves]
+        })
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'resource.calendar',
+            'res_id': self.calendar_id.id,
+            'view_mode': 'form',
+        }

--- a/hr_holidays_public/wizards/resource_calendar_leaves_wizard.xml
+++ b/hr_holidays_public/wizards/resource_calendar_leaves_wizard.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="public_holidays_resource_calendar_leaves_wizard_view_form" model="ir.ui.view">
+        <field name="name">Create Resource Leaves from Public Holidays</field>
+        <field name="model">public.holidays.resource.calendar.leaves.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div>
+                        Use this wizard to generate global leaves for resource calendar from public holidays.
+                    </div>
+                    <group>
+                        <group>
+                            <field name="holidays_id"/>
+                            <field name="calendar_id"/>
+                            <field name="replace"/>
+                        </group>
+                    </group>
+                </sheet>
+                <footer>
+                    <button name="create_leaves" string="Generate" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="public_holidays_resource_calendar_leaves_wizard_action" model="ir.actions.act_window">
+        <field name="name">Generate Resource Leaves</field>
+        <field name="res_model">public.holidays.resource.calendar.leaves.wizard</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="public_holidays_resource_calendar_leaves_wizard_action_menu"
+        action="public_holidays_resource_calendar_leaves_wizard_action"
+        parent="menu_hr_public_holidays"
+        groups="hr_holidays.group_hr_holidays_manager"
+        sequence="50"/>
+</odoo>


### PR DESCRIPTION
A simple wizard to easily generate leaves for selected resource calendar from public holidays by choosing desired `resource.calendar` and `hr.holidays.public` record. Optionally replaces existing global leaves on resource.