### PR TITLE
[FIX] [13.0] hr_employee_calendar_planning: Defuse warning about non-matching calendars.

### DIFF
--- a/hr_employee_calendar_planning/models/__init__.py
+++ b/hr_employee_calendar_planning/models/__init__.py
@@ -1,2 +1,3 @@
+from . import hr_contract
 from . import hr_employee
 from . import resource_calendar

--- a/hr_employee_calendar_planning/models/hr_contract.py
+++ b/hr_employee_calendar_planning/models/hr_contract.py
@@ -9,4 +9,5 @@ class HrContract(models.Model):
 
     # defuse this, it makes no sense when this module is active
     def _compute_calendar_mismatch(self):
-        return False
+        for contract in self:
+            contract.calendar_mismatch = False

--- a/hr_employee_calendar_planning/models/hr_contract.py
+++ b/hr_employee_calendar_planning/models/hr_contract.py
@@ -1,0 +1,12 @@
+# Copyright 2020 Sunflower IT
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class HrContract(models.Model):
+    _inherit = "hr.contract"
+
+    # defuse this, it makes no sense when this module is active
+    def _compute_calendar_mismatch(self):
+        return False


### PR DESCRIPTION
Disables the warning of 'Calendar Mismatch : The employee's calendar does not match its current contract calendar. This could lead to unexpected behaviors.'.

It makes no sense as the point of this module is to replace the employee's calendar by a generated one.
                            