### PR TITLE
[12.0][FIX] name duplicate with module hr_expense_advance_clearing

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense.py
+++ b/hr_expense_advance_clearing/models/hr_expense.py
@@ -51,7 +51,7 @@ class HrExpense(models.Model):
                                    'product_emp_advance')
         sheets = self.mapped('sheet_id').filtered('advance_sheet_id')
         sheets_x = sheets.filtered(lambda x: x.advance_sheet_residual <= 0.0)
-        if sheets_x:  # Advance Sheets with no residual left
+        if sheets_x:  # Advance Sheets with no clearing residual left
             raise ValidationError(_('Advance: %s has no amount to clear') %
                                   ', '.join(sheets_x.mapped('name')))
         for sheet in sheets:

--- a/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
+++ b/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
@@ -142,7 +142,7 @@ class TestHrExpenseAdvanceClearing(common.SavepointCase):
         self.advance.action_submit_sheet()
         self.advance.approve_expense_sheets()
         self.advance.action_sheet_move_create()
-        self.assertEqual(self.advance.residual, 1000.0)
+        self.assertEqual(self.advance.clearing_residual, 1000.0)
         self._register_payment(self.advance)
         self.assertEqual(self.advance.state, 'done')
         # ------------------ Clearing --------------------------
@@ -165,7 +165,7 @@ class TestHrExpenseAdvanceClearing(common.SavepointCase):
         self.advance.action_submit_sheet()
         self.advance.approve_expense_sheets()
         self.advance.action_sheet_move_create()
-        self.assertEqual(self.advance.residual, 1000.0)
+        self.assertEqual(self.advance.clearing_residual, 1000.0)
         self._register_payment(self.advance)
         self.assertEqual(self.advance.state, 'done')
         # ------------------ Clearing --------------------------
@@ -187,7 +187,7 @@ class TestHrExpenseAdvanceClearing(common.SavepointCase):
         self.advance.action_submit_sheet()
         self.advance.approve_expense_sheets()
         self.advance.action_sheet_move_create()
-        self.assertEqual(self.advance.residual, 1000.0)
+        self.assertEqual(self.advance.clearing_residual, 1000.0)
         self._register_payment(self.advance)
         self.assertEqual(self.advance.state, 'done')
         # ------------------ Clearing --------------------------
@@ -200,6 +200,6 @@ class TestHrExpenseAdvanceClearing(common.SavepointCase):
         # Less amount, state set to done. Still remain 200 to be returned
         self.assertEqual(self.clearing_less.state, 'done')
         self.assertEqual(self.clearing_less.advance_sheet_residual, 200.0)
-        # Back to advance and do return advance, residual become 0.0
+        # Back to advance and do return advance, clearing residual become 0.0
         self._register_payment(self.advance, hr_return_advance=True)
-        self.assertEqual(self.advance.residual, 0.0)
+        self.assertEqual(self.advance.clearing_residual, 0.0)

--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <separator position="after">
                 <filter string="Advance" name="advance_expense" domain="[('advance', '=', True)]"/>
-                <filter string="Advance (not cleared)" name="advance_expense_uncleared" domain="[('advance', '=', True), ('residual', '>', 0.0)]"/>
+                <filter string="Advance (not cleared)" name="advance_expense_uncleared" domain="[('advance', '=', True), ('clearing_residual', '>', 0.0)]"/>
                 <filter string="Clearing" name="advance_clearing" domain="[('advance_sheet_id', '!=', False)]"/>
             </separator>
         </field>
@@ -53,10 +53,10 @@
         <field name="arch" type="xml">
             <field name="state" position="before">
                 <button name="open_clear_advance" type="object" string="Clear Advance" class="oe_highlight"
-                  attrs="{'invisible': ['|', '|', ('advance', '=', False), ('state', '!=', 'done'), ('residual', '=', 0.0)]}"
+                  attrs="{'invisible': ['|', '|', ('advance', '=', False), ('state', '!=', 'done'), ('clearing_residual', '=', 0.0)]}"
                   groups="account.group_account_manager" />
                 <button name="%(hr_expense.hr_expense_sheet_register_payment_wizard_action)d" type="action" string="Return Advance"
-                  attrs="{'invisible': ['|', '|', ('advance', '=', False), ('state', '!=', 'done'), ('residual', '=', 0.0)]}"
+                  attrs="{'invisible': ['|', '|', ('advance', '=', False), ('state', '!=', 'done'), ('clearing_residual', '=', 0.0)]}"
                   context="{'hr_return_advance': True, 'partner_id': address_id}" groups="account.group_account_manager"/>
             </field>
             <h1 position="after">
@@ -66,7 +66,7 @@
             <xpath expr="/form/sheet/group/group" position="after">
                 <group>
                     <field name="advance_sheet_id" attrs="{'invisible': [('advance', '=', True)]}"/>
-                    <field name="residual" attrs="{'invisible': [('advance', '=', False)]}"/>
+                    <field name="clearing_residual" attrs="{'invisible': [('advance', '=', False)]}"/>
                     <field name="advance_sheet_residual" attrs="{'invisible': [('advance_sheet_id', '=', False)]}"/>
                 </group>
             </xpath>

--- a/hr_expense_advance_clearing/wizard/hr_expense_sheet_register_payment.py
+++ b/hr_expense_advance_clearing/wizard/hr_expense_sheet_register_payment.py
@@ -14,7 +14,7 @@ class HrExpenseSheetRegisterPaymentWizard(models.TransientModel):
         ctx = self._context.copy()
         sheet = self.env['hr.expense.sheet'].browse(ctx.get('active_id'))
         if ctx.get('hr_return_advance', False):
-            res.update({'amount': sheet.residual})
+            res.update({'amount': sheet.clearing_residual})
         else:
             res.update({'amount': sheet.amount_payable})
         return res

--- a/hr_expense_payment_difference/models/hr_expense.py
+++ b/hr_expense_payment_difference/models/hr_expense.py
@@ -7,13 +7,13 @@ from odoo import models, fields
 class HRExpenseSheet(models.Model):
     _inherit = 'hr.expense.sheet'
 
-    residual = fields.Monetary(
-        compute='_compute_residual',
+    difference_residual = fields.Monetary(
+        compute='_compute_difference_residual',
     )
 
-    def _compute_residual(self):
+    def _compute_difference_residual(self):
         for sheet in self:
             types = ('payable', 'receivable')
             lines = sheet.account_move_id.line_ids.filtered(
                 lambda l: l.account_id.user_type_id.type in types)
-            sheet.residual = abs(sum(lines.mapped('amount_residual')))
+            sheet.difference_residual = abs(sum(lines.mapped('amount_residual')))

--- a/hr_expense_payment_difference/wizards/hr_expense_sheet_register_payment.py
+++ b/hr_expense_payment_difference/wizards/hr_expense_sheet_register_payment.py
@@ -36,7 +36,7 @@ class HrExpenseSheetRegisterPaymentWizard(models.TransientModel):
         active_id = self._context.get('active_id')
         if self._context.get('active_model') == 'hr.expense.sheet' and active_id:
             sheet = self.env['hr.expense.sheet'].browse(active_id)
-            res['amount'] = sheet.residual
+            res['amount'] = sheet.difference_residual
         return res
 
     def _get_payment_vals(self):
@@ -52,7 +52,7 @@ class HrExpenseSheetRegisterPaymentWizard(models.TransientModel):
     def _compute_payment_amount(self):
         active_id = self._context.get('active_id', False)
         expense_sheet = self.env['hr.expense.sheet'].browse(active_id)
-        return expense_sheet.residual
+        return expense_sheet.difference_residual
 
     @api.depends('amount', 'payment_date', 'currency_id')
     def _compute_payment_difference(self):


### PR DESCRIPTION
rename field `residual` on 2 module
- hr_expense_advance_clearing - rename to `clearing_residual`
- hr_expense_payment_difference - rename to `difference_residual`

reference : https://github.com/OCA/hr/issues/955