### PR TITLE
[FIX] theoretical_time: Issue with postgres 12

### DIFF
--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
@@ -64,7 +64,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
                 ('x'||substr(MD5('HA' || ha.id::text), 1, 8))::bit(32)::int
             ) AS id,
             ha.employee_id AS employee_id,
-            he.department_id AS department_id,
+            hahe.department_id AS department_id,
             ha.check_in::date AS date,
             ha.worked_hours AS worked_hours,
             ha.theoretical_hours AS theoretical_hours,
@@ -74,7 +74,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
     def _from_sub1(self):
         return """
             hr_attendance ha
-            LEFT JOIN hr_employee AS he ON ha.employee_id = he.id
+            LEFT JOIN hr_employee AS hahe ON ha.employee_id = hahe.id
             """
 
     def _where_sub1(self):


### PR DESCRIPTION
On the last update of theoretical time #961 , I was unable to use it on postgres 12.
This PR tries to fix it. 

Theoretically, Odoo should be compatible with all Postgres Versions after 9.5