### PR TITLE
[12.0][FIX] hr_expense_invoice: Set groups to invoice_id field in expense view

### DIFF
--- a/hr_expense_invoice/readme/CONTRIBUTORS.rst
+++ b/hr_expense_invoice/readme/CONTRIBUTORS.rst
@@ -2,5 +2,6 @@
 
   * Pedro M. Baeza
   * Vicent Cubells
+  * Víctor Martínez
 
 * Kitti Upariphutthiphong <kittiu@ecosoft.co.th>

--- a/hr_expense_invoice/views/hr_expense_views.xml
+++ b/hr_expense_invoice/views/hr_expense_views.xml
@@ -5,6 +5,7 @@
         <field name="name">hr.expense.form</field>
         <field name="model">hr.expense</field>
         <field name="inherit_id" ref="hr_expense.hr_expense_view_form"/>
+        <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
         <field name="arch" type="xml">
             <field name="product_id" position="after">
                 <field name="invoice_id"
@@ -32,11 +33,12 @@
         <field name="name">hr.expense.sheet.form.inherit.sale.expense</field>
         <field name="model">hr.expense.sheet</field>
         <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_form"/>
+        <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
         <field name="arch" type="xml">
             <button name="action_sheet_move_create" position="after">
                 <field name="invoice_fully_created" invisible="1"/>
                 <button name="%(action_expense_create_invoice)d" type="action"
-                    string="Create Vendor Bill" groups="account.group_account_invoice" class="oe_highlight"
+                    string="Create Vendor Bill" class="oe_highlight"
                     attrs="{'invisible': ['|', ('state', '!=', 'approve'), ('invoice_fully_created', '=', True)]}"/>
             </button>
             <xpath expr="//field[@name='expense_line_ids']/tree/field[@name='name']" position="after">
@@ -45,8 +47,7 @@
             <div class="oe_button_box" position="inside">
                 <button class="oe_stat_button" icon="fa-book"
                         name="action_view_invoices" type="object"
-                        attrs="{'invisible': [('invoice_count', '=', 0)]}"
-                        groups="account.group_account_invoice">
+                        attrs="{'invisible': [('invoice_count', '=', 0)]}">
                     <field name="invoice_count" widget="statinfo" string="Invoices"/>
                 </button>
             </div>


### PR DESCRIPTION
Set groups to `invoice_id` field in expense view

Related to 13.0 https://github.com/OCA/hr-expense/pull/28

@Tecnativa TT28121