### PR TITLE
[FIX] hr_employee_firstname: Avoid access error on employee update

### DIFF
--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -51,9 +51,9 @@ class HrEmployee(models.Model):
     @api.model
     def _is_partner_firstname_installed(self):
         return bool(
-            self.env["ir.module.module"].search(
-                [("name", "=", "partner_firstname"), ("state", "=", "installed")]
-            )
+            self.env["ir.module.module"]
+            .sudo()
+            .search([("name", "=", "partner_firstname"), ("state", "=", "installed")])
         )
 
     @api.model


### PR DESCRIPTION
``sudo`` is used to avoid access error when verify that module is installed.

Avoid error in the next case:
1. Create a new user without settings access (HR User)
2. Login with the user in 1, and try to edit an employee