### PR TITLE
[12.0][FIX] hr_holidays_validity_date: Check for `restrict_dates` when validating an allocation

### DIFF
--- a/hr_holidays_validity_date/models/__init__.py
+++ b/hr_holidays_validity_date/models/__init__.py
@@ -1,1 +1,2 @@
 from . import hr_leave
+from . import hr_leave_allocation

--- a/hr_holidays_validity_date/models/hr_leave_allocation.py
+++ b/hr_holidays_validity_date/models/hr_leave_allocation.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, api
+
+
+class HolidaysAllocation(models.Model):
+    _inherit = "hr.leave.allocation"
+
+    @api.multi
+    @api.constrains('holiday_status_id')
+    def _check_leave_type_validity(self):
+        super(
+            HolidaysAllocation,
+            self.filtered('holiday_status_id.restrict_dates')
+        )._check_leave_type_validity()


### PR DESCRIPTION
In the initial behavior, the `_check_leave_type_validity` is overridden only for the `hr.leave` model but the same constraint exist in the built-in implementation of the `hr.leave.allocation` model.

This commit ensures consistent operation on both models.