### PR TITLE
[FIX] hr_employee_{firstname,lastnames}: Move fields to common employee

### DIFF
--- a/hr_employee_firstname/models/__init__.py
+++ b/hr_employee_firstname/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import base_config_settings
+from . import hr_employee_base
 from . import hr_employee

--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from odoo import _, api, fields, models
+from odoo import _, api, models
 from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
@@ -44,9 +44,6 @@ class HrEmployee(models.Model):
     def _onchange_firstname_lastname(self):
         if self.firstname or self.lastname:
             self.name = self._get_name(self.lastname, self.firstname)
-
-    firstname = fields.Char()
-    lastname = fields.Char()
 
     @api.model
     def _is_partner_firstname_installed(self):

--- a/hr_employee_firstname/models/hr_employee_base.py
+++ b/hr_employee_firstname/models/hr_employee_base.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class HrEmployeeBase(models.AbstractModel):
+    _inherit = "hr.employee.base"
+
+    firstname = fields.Char()
+    lastname = fields.Char()

--- a/hr_employee_lastnames/models/__init__.py
+++ b/hr_employee_lastnames/models/__init__.py
@@ -1,1 +1,2 @@
+from . import hr_employee_base
 from . import hr_employee

--- a/hr_employee_lastnames/models/hr_employee.py
+++ b/hr_employee_lastnames/models/hr_employee.py
@@ -1,6 +1,6 @@
 import logging
 
-from odoo import api, fields, models
+from odoo import api, models
 
 from odoo.addons.hr_employee_firstname.models.hr_employee import UPDATE_PARTNER_FIELDS
 
@@ -11,10 +11,6 @@ UPDATE_PARTNER_FIELDS += ["lastname2"]
 
 class HrEmployee(models.Model):
     _inherit = "hr.employee"
-
-    firstname = fields.Char("First name")
-    lastname = fields.Char("Last name")
-    lastname2 = fields.Char("Second last name")
 
     @api.model
     def _get_name_lastnames(self, lastname, firstname, lastname2=None):

--- a/hr_employee_lastnames/models/hr_employee_base.py
+++ b/hr_employee_lastnames/models/hr_employee_base.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class HrEmployeeBase(models.AbstractModel):
+    _inherit = "hr.employee.base"
+
+    firstname = fields.Char("First name")
+    lastname = fields.Char("Last name")
+    lastname2 = fields.Char("Second last name")


### PR DESCRIPTION
[FIX] hr_employee_{firstname,lastnames}: Move fields to common employee

Starting from 14.0, employee model was split into three models:
- `hr.employee.public`
- `hr.employee.private`
- `hr.employee` (a common model)

When this module was migrated, such  split was not taken into account.

This commit moves fields to the common model, so they don't fail when
read from the public employee model.

Closes #990