### PR TITLE
[13.0][FIX] hr_employee_calendar_planning: Prevent disable resource.calendar when is related to some employee

### DIFF
--- a/hr_employee_calendar_planning/i18n/es.po
+++ b/hr_employee_calendar_planning/i18n/es.po
@@ -6,15 +6,26 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2020-01-16 20:00+0000\n"
+"POT-Creation-Date: 2021-07-13 11:53+0000\n"
+"PO-Revision-Date: 2021-07-13 13:55+0200\n"
 "Last-Translator: Carles Antoli <carlesantoli@hotmail.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.10\n"
+"X-Generator: Poedit 2.3\n"
+
+#. module: hr_employee_calendar_planning
+#: code:addons/hr_employee_calendar_planning/models/resource_calendar.py:0
+#, python-format
+msgid ""
+"%s is related to %s employee(s) in calendar planing, you should change it "
+"first."
+msgstr ""
+"%s está relacionado a %s empleado(s) en las horas laborales, deberías "
+"cambiarlo primero."
 
 #. module: hr_employee_calendar_planning
 #: model:ir.model.fields,field_description:hr_employee_calendar_planning.field_resource_calendar__active

--- a/hr_employee_calendar_planning/i18n/hr_employee_calendar_planning.pot
+++ b/hr_employee_calendar_planning/i18n/hr_employee_calendar_planning.pot
@@ -6,12 +6,22 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-13 11:53+0000\n"
+"PO-Revision-Date: 2021-07-13 11:53+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: hr_employee_calendar_planning
+#: code:addons/hr_employee_calendar_planning/models/resource_calendar.py:0
+#, python-format
+msgid ""
+"%s is related to %s employee(s) in calendar planing, you should change it "
+"first."
+msgstr ""
 
 #. module: hr_employee_calendar_planning
 #: model:ir.model.fields,field_description:hr_employee_calendar_planning.field_resource_calendar__active

--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -1,13 +1,27 @@
 # Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResourceCalendar(models.Model):
     _inherit = "resource.calendar"
 
     active = fields.Boolean(default=True)
+
+    @api.constrains("active")
+    def _check_active(self):
+        for item in self:
+            total_items = self.env["hr.employee.calendar"].search_count(
+                [("calendar_id", "=", item.id)]
+            )
+            if total_items:
+                raise ValidationError(
+                    _("%s is used in %s employee(s). You should change them first.")
+                    % (item.name, total_items)
+                )
 
     def write(self, vals):
         res = super(ResourceCalendar, self).write(vals)

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -1,7 +1,8 @@
 # Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields
+from odoo import exceptions, fields
 from odoo.tests import common
 
 from ..hooks import post_init_hook
@@ -171,3 +172,13 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
         self.assertEqual(
             len(self.employee.calendar_ids[1].calendar_id.attendance_ids), 8,
         )
+
+    def test_resource_calendar_constraint(self):
+        self.employee.calendar_ids = [
+            (0, 0, {"date_end": "2019-12-31", "calendar_id": self.calendar1.id})
+        ]
+        with self.assertRaises(exceptions.ValidationError):
+            self.calendar1.write({"active": False})
+        self.employee.write({"calendar_ids": [(2, self.employee.calendar_ids.id)]})
+        self.calendar1.write({"active": False})
+        self.assertFalse(self.calendar1.active)


### PR DESCRIPTION
Prevent disable `resource.calendar` when is related to some employee.

It's need to change in 14.0 too.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT31007