### PR TITLE
[FIX] hr_employee_relative: change attribute replace by invisible

### DIFF
--- a/hr_employee_relative/views/hr_employee.xml
+++ b/hr_employee_relative/views/hr_employee.xml
@@ -9,9 +9,9 @@
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form" />
         <field name="arch" type="xml">
-            <field name="spouse_complete_name" position="replace" />
-            <field name="spouse_birthdate" position="replace" />
-            <field name="children" position="replace" />
+            <xpath expr="//field[@name='children']/.." position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
             <div name="button_box" position="inside">
                 <button
                     name="action_view_relatives"


### PR DESCRIPTION
While inheriting the view_employee_form I found the problem that I could not use the field 'children' because it was replaced. To solve this problem, the 'replace' attribute of some fields has been changed to 'invisible'. The 'Dependant' group has also been made invisible. 