### PR TITLE
[13.0][FIX] hr_employee_calendar_planning: Add check_company to calendar_id field in to show only allowed records according to company

### DIFF
--- a/hr_employee_calendar_planning/i18n/es.po
+++ b/hr_employee_calendar_planning/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-13 11:53+0000\n"
-"PO-Revision-Date: 2021-07-13 13:55+0200\n"
+"POT-Creation-Date: 2021-07-28 06:32+0000\n"
+"PO-Revision-Date: 2021-07-28 08:34+0200\n"
 "Last-Translator: Carles Antoli <carlesantoli@hotmail.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -20,8 +20,14 @@ msgstr ""
 #. module: hr_employee_calendar_planning
 #: code:addons/hr_employee_calendar_planning/models/resource_calendar.py:0
 #, python-format
+msgid "%s is used in %s employee(s) related to another company."
+msgstr "%s está usado con el  empleado(s) %s relacionado con otra compañía."
+
+#. module: hr_employee_calendar_planning
+#: code:addons/hr_employee_calendar_planning/models/resource_calendar.py:0
+#, python-format
 msgid "%s is used in %s employee(s). You should change them first."
-msgstr ""
+msgstr "%s está usado con el empleado(s) %s . Deberías cambiarlo primero."
 
 #. module: hr_employee_calendar_planning
 #: model:ir.model.fields,field_description:hr_employee_calendar_planning.field_resource_calendar__active
@@ -38,6 +44,11 @@ msgstr "Horario autogenerado para el empleado"
 #: model:ir.model.fields,field_description:hr_employee_calendar_planning.field_hr_employee__calendar_ids
 msgid "Calendar planning"
 msgstr "Plan de Horario"
+
+#. module: hr_employee_calendar_planning
+#: model:ir.model.fields,field_description:hr_employee_calendar_planning.field_hr_employee_calendar__company_id
+msgid "Company"
+msgstr "Compañía"
 
 #. module: hr_employee_calendar_planning
 #: model:ir.model.fields,field_description:hr_employee_calendar_planning.field_hr_employee_calendar__create_uid
@@ -109,10 +120,3 @@ msgstr "Fecha de Inicio"
 #: model:ir.model.fields,field_description:hr_employee_calendar_planning.field_hr_employee_calendar__calendar_id
 msgid "Working Time"
 msgstr "Tiempo de Trabajo"
-
-#~ msgid ""
-#~ "%s is related to %s employee(s) in calendar planing, you should change it "
-#~ "first."
-#~ msgstr ""
-#~ "%s está relacionado a %s empleado(s) en las horas laborales, deberías "
-#~ "cambiarlo primero."

--- a/hr_employee_calendar_planning/i18n/hr_employee_calendar_planning.pot
+++ b/hr_employee_calendar_planning/i18n/hr_employee_calendar_planning.pot
@@ -6,12 +6,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-28 06:32+0000\n"
+"PO-Revision-Date: 2021-07-28 06:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: hr_employee_calendar_planning
+#: code:addons/hr_employee_calendar_planning/models/resource_calendar.py:0
+#, python-format
+msgid "%s is used in %s employee(s) related to another company."
+msgstr ""
 
 #. module: hr_employee_calendar_planning
 #: code:addons/hr_employee_calendar_planning/models/resource_calendar.py:0
@@ -33,6 +41,11 @@ msgstr ""
 #. module: hr_employee_calendar_planning
 #: model:ir.model.fields,field_description:hr_employee_calendar_planning.field_hr_employee__calendar_ids
 msgid "Calendar planning"
+msgstr ""
+
+#. module: hr_employee_calendar_planning
+#: model:ir.model.fields,field_description:hr_employee_calendar_planning.field_hr_employee_calendar__company_id
+msgid "Company"
 msgstr ""
 
 #. module: hr_employee_calendar_planning

--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -124,8 +124,12 @@ class HrEmployeeCalendar(models.Model):
     employee_id = fields.Many2one(
         comodel_name="hr.employee", string="Employee", required=True,
     )
+    company_id = fields.Many2one(related="employee_id.company_id")
     calendar_id = fields.Many2one(
-        comodel_name="resource.calendar", string="Working Time", required=True,
+        comodel_name="resource.calendar",
+        string="Working Time",
+        required=True,
+        check_company=True,
     )
 
     _sql_constraints = [

--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -23,6 +23,21 @@ class ResourceCalendar(models.Model):
                     % (item.name, total_items)
                 )
 
+    @api.constrains("company_id")
+    def _check_company_id(self):
+        for item in self.filtered("company_id"):
+            total_items = self.env["hr.employee.calendar"].search_count(
+                [
+                    ("calendar_id.company_id", "=", item.company_id.id),
+                    ("employee_id.company_id", "!=", item.company_id.id),
+                ]
+            )
+            if total_items:
+                raise ValidationError(
+                    _("%s is used in %s employee(s) related to another company.")
+                    % (item.name, total_items)
+                )
+
     def write(self, vals):
         res = super(ResourceCalendar, self).write(vals)
         if "attendance_ids" in vals:

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -182,3 +182,14 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
         self.employee.write({"calendar_ids": [(2, self.employee.calendar_ids.id)]})
         self.calendar1.write({"active": False})
         self.assertFalse(self.calendar1.active)
+
+    def test_resource_calendar_constraint_company_id(self):
+        main_company = self.env.ref("base.main_company")
+        self.calendar1.company_id = main_company
+        self.employee.company_id = main_company
+        self.employee.calendar_ids = [
+            (0, 0, {"date_end": "2019-12-31", "calendar_id": self.calendar1.id})
+        ]
+        company2 = self.env["res.company"].create({"name": "Test company"})
+        with self.assertRaises(exceptions.ValidationError):
+            self.calendar1.company_id = company2

--- a/hr_employee_calendar_planning/views/hr_employee_views.xml
+++ b/hr_employee_calendar_planning/views/hr_employee_views.xml
@@ -10,8 +10,12 @@
                 <attribute name="invisible">1</attribute>
             </field>
             <field name="resource_calendar_id" position="after">
-                <field name="calendar_ids">
+                <field
+                    name="calendar_ids"
+                    context="{'default_company_id': parent.company_id}"
+                >
                     <tree editable="top">
+                        <field name="company_id" invisible="1" />
                         <field name="date_start" />
                         <field name="date_end" />
                         <field name="calendar_id" />


### PR DESCRIPTION
Add `check_company` to `calendar_id` field in to show only allowed records according to company.
Add constraint to prevent change avoid changing the company when the calendar is linked to an employee of another company.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT31201
