### PR TITLE
[11.0][FIX] hr_holidays_settings: wrong header in Settings

### DIFF
--- a/hr_holidays_settings/views/res_config_settings.xml
+++ b/hr_holidays_settings/views/res_config_settings.xml
@@ -19,7 +19,7 @@
     </record>
 
     <record id="hr_holidays_config_settings_action" model="ir.actions.act_window">
-        <field name="name">Configure HR Holidays</field>
+        <field name="name">Settings</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">res.config.settings</field>
         <field name="view_mode">form</field>


### PR DESCRIPTION
Set correct Header for Settings Page in res.config.settings

Steps to reproduce:

Install hr_holidays_settings
Go to Settings -> In all "Sections" is the header "Configure HR Holidays"