### PR TITLE
[13.0][FIX] hr_employee_document: Add security rule to allow user without employee groups can access to attachments related to own employee

### DIFF
--- a/hr_employee_document/README.rst
+++ b/hr_employee_document/README.rst
@@ -25,12 +25,21 @@ HR Employee Document
 
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
-This module allows to attach documents to the employee profile.
+This module displays a button on the employee's profile to view linked attachments, both
+for HR officers/managers and the own employee, so you can use it as employee document storage.
 
 **Table of contents**
 
 .. contents::
    :local:
+
+Known issues / Roadmap
+======================
+
+This module adds read permission to the employee model; the rest of the model data will
+be available to the employee.
+If another module grants permissions to the employee model (Pre-officer for example),
+I will need to create a rule to extend the basic permissions.
 
 Bug Tracker
 ===========

--- a/hr_employee_document/__manifest__.py
+++ b/hr_employee_document/__manifest__.py
@@ -14,5 +14,9 @@
     "application": False,
     "summary": "Documents attached to the employee profile",
     "depends": ["hr"],
-    "data": ["views/hr_employee.xml", "views/hr_employee_public.xml"],
+    "data": [
+        "security/security.xml",
+        "views/hr_employee.xml",
+        "views/hr_employee_public.xml",
+    ],
 }

--- a/hr_employee_document/readme/DESCRIPTION.rst
+++ b/hr_employee_document/readme/DESCRIPTION.rst
@@ -1,1 +1,2 @@
-This module allows to attach documents to the employee profile.
+This module displays a button on the employee's profile to view linked attachments, both
+for HR officers/managers and the own employee, so you can use it as employee document storage.

--- a/hr_employee_document/readme/ROADMAP.rst
+++ b/hr_employee_document/readme/ROADMAP.rst
@@ -1,0 +1,4 @@
+This module adds read permission to the employee model; the rest of the model data will
+be available to the employee.
+If another module grants permissions to the employee model (Pre-officer for example),
+I will need to create a rule to extend the basic permissions.

--- a/hr_employee_document/security/security.xml
+++ b/hr_employee_document/security/security.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="access_hr_employee_system_user_override" model="ir.model.access">
+        <field name="name">hr.employee system user override</field>
+        <field name="model_id" ref="hr.model_hr_employee" />
+        <field name="group_id" ref="base.group_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+    <record id="rule_hr_employee_user" model="ir.rule">
+        <field name="name">User can only read their own employees</field>
+        <field name="model_id" ref="hr.model_hr_employee" />
+        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+        <field name="domain_force">[('id','in', user.employee_ids.ids)]</field>
+    </record>
+    <record id="rule_hr_employee_hr_user" model="ir.rule">
+        <field name="name">Hr user can access to all records</field>
+        <field name="model_id" ref="hr.model_hr_employee" />
+        <field name="groups" eval="[(4, ref('hr.group_hr_user'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+</odoo>

--- a/hr_employee_document/static/description/index.html
+++ b/hr_employee_document/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>HR Employee Document</title>
 <style type="text/css">
 
@@ -368,21 +368,30 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/hr/tree/13.0/hr_employee_document"><img alt="OCA/hr" src="https://img.shields.io/badge/github-OCA%2Fhr-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/hr-13-0/hr-13-0-hr_employee_document"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/116/13.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
-<p>This module allows to attach documents to the employee profile.</p>
+<p>This module displays a button on the employee’s profile to view linked attachments, both
+for HR officers/managers and the own employee, so you can use it as employee document storage.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="id1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id5">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id1">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
+<p>This module adds read permission to the employee model; the rest of the model data will
+be available to the employee.
+If another module grants permissions to the employee model (Pre-officer for example),
+I will need to create a rule to extend the basic permissions.</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/hr/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -390,15 +399,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id2">Credits</a></h1>
+<h1><a class="toc-backref" href="#id3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id3">Authors</a></h2>
+<h2><a class="toc-backref" href="#id4">Authors</a></h2>
 <ul class="simple">
 <li>CorporateHub</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul>
 <li><p class="first"><a class="reference external" href="https://corporatehub.eu/">CorporateHub</a></p>
 <ul class="simple">
@@ -417,7 +426,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/hr_employee_document/tests/test_hr_employee_document.py
+++ b/hr_employee_document/tests/test_hr_employee_document.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Brainbean Apps (https://brainbeanapps.com)
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import base64
@@ -9,29 +10,77 @@ from odoo.tests import common
 class TestHrEmployeeDocument(common.TransactionCase):
     def setUp(self):
         super().setUp()
-
         self.Employee = self.env["hr.employee"]
         self.EmployeePublic = self.env["hr.employee.public"]
         self.SudoEmployee = self.Employee.sudo()
         self.Attachment = self.env["ir.attachment"]
         self.SudoAttachment = self.Attachment.sudo()
+        self.employee_1 = self.SudoEmployee.create({"name": "Employee #1"})
+        self.employee_2 = self.SudoEmployee.create({"name": "Employee #2"})
 
-    def test_employee_attachment(self):
-        employee = self.SudoEmployee.create({"name": "Employee #1"})
-        self.SudoAttachment.create(
+    def _create_attachment(self, employee_id):
+        return self.SudoAttachment.create(
             {
                 "res_model": self.Employee._name,
-                "res_id": employee.id,
+                "res_id": employee_id.id,
                 "datas": base64.b64encode(b"My attachment"),
                 "name": "doc.txt",
             }
         )
-        self.assertEqual(employee.document_count, 1)
-        employee_public = self.EmployeePublic.browse(employee.id)
+
+    def _create_user_from_employee(self, employee_id):
+        user = self.env["res.users"].create(
+            {
+                "name": employee_id.name,
+                "login": employee_id.name,
+                "groups_id": [(6, 0, [self.env.ref("base.group_user").id])],
+            }
+        )
+        employee_id.user_id = user.id
+        return user
+
+    def test_employee_attachment(self):
+        self._create_attachment(self.employee_1)
+        self.assertEqual(self.employee_1.document_count, 1)
+        employee_public = self.EmployeePublic.browse(self.employee_1.id)
         self.assertEqual(employee_public.document_count, 1)
 
     def test_employee_attachment_tree_view(self):
-        employee = self.SudoEmployee.create({"name": "Employee #2"})
-        self.assertNotEqual(employee.action_get_attachment_tree_view(), None)
-        employee_public = self.EmployeePublic.browse(employee.id)
+        self.assertNotEqual(self.employee_2.action_get_attachment_tree_view(), None)
+        employee_public = self.EmployeePublic.browse(self.employee_2.id)
         self.assertNotEqual(employee_public.action_get_attachment_tree_view(), None)
+
+    def test_attachments_access(self):
+        # create records (users and attachments)
+        user_manager = self.env["res.users"].create(
+            {
+                "name": "user_manager",
+                "login": "user_manager",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("hr.group_hr_user").id,
+                        ],
+                    )
+                ],
+            }
+        )
+        user_1 = self._create_user_from_employee(self.employee_1)
+        user_2 = self._create_user_from_employee(self.employee_2)
+        attachment_1 = self._create_attachment(self.employee_1)
+        attachment_2 = self._create_attachment(self.employee_2)
+        # user_1
+        records = self.Attachment.with_user(user_1).search([])
+        self.assertTrue(attachment_1 in records)
+        self.assertFalse(attachment_2 in records)
+        # user_2
+        records = self.Attachment.with_user(user_2).search([])
+        self.assertFalse(attachment_1 in records)
+        self.assertTrue(attachment_2 in records)
+        # user_manager
+        records = self.Attachment.with_user(user_manager).search([])
+        self.assertTrue(attachment_1 in records)
+        self.assertTrue(attachment_2 in records)


### PR DESCRIPTION
Add security rule to allow user without employee groups can access to attachments related to own employee.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT31359
