### PR TITLE
[12.0][FIX] hr_expense_invoice: Assign the partner_id and account_id correctly in the linked accounting entries of expenses with invoices.

### DIFF
--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -71,7 +71,7 @@ class HrExpense(models.Model):
         for expense_id, move_lines in move_line_values_by_expense.items():
             expense = self.browse(expense_id)
             if not expense.invoice_id:
-                return move_line_values_by_expense
+                continue
             for move_line in move_lines:
                 if move_line['debit']:
                     move_line['partner_id'] = \

--- a/hr_expense_invoice/tests/test_hr_expense_invoice.py
+++ b/hr_expense_invoice/tests/test_hr_expense_invoice.py
@@ -222,3 +222,22 @@ class TestHrExpenseInvoice(common.SavepointCase):
             self.sheet._validate_expense_invoice(expense_line_ids)
         self.expense.write({'unit_amount': 100.0})  # set to 100.0
         self.sheet._validate_expense_invoice(expense_line_ids)
+
+    def test_5_hr_test_multi_invoice(self):
+        # We add 2 expenses
+        self.expense.unit_amount = 200.0
+        self.expense2.unit_amount = 100.0
+        self.sheet.expense_line_ids = [(6, 0, [self.expense.id,
+                                               self.expense2.id])]
+        # We add invoice to expense
+        self.invoice.action_invoice_open()
+        self.expense2.invoice_id = self.invoice.id
+        # We approve sheet
+        self.sheet.approve_expense_sheets()
+        # We post journal entries
+        self.sheet.action_sheet_move_create()
+        line_expense_2 = self.sheet.account_move_id.line_ids.filtered(
+            lambda x: x.debit == 100
+        )
+        self.assertEqual(line_expense_2.partner_id, self.invoice.partner_id)
+        self.assertEqual(line_expense_2.account_id, self.invoice.account_id)


### PR DESCRIPTION
Assign the partner_id and account_id correctly in the linked accounting entries of expenses with invoices.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT32050