### PR TITLE
[FIX] hr_employee_service_contract: Set fields as not prefetched

### DIFF
--- a/hr_employee_service_contract/models/hr_employee.py
+++ b/hr_employee_service_contract/models/hr_employee.py
@@ -11,6 +11,7 @@ class HrEmployee(models.Model):
         "hr.contract",
         compute="_compute_first_contract_id",
         store=True,
+        prefetch=False,
         string="First Contract",
         help="First contract of the employee",
     )
@@ -18,14 +19,21 @@ class HrEmployee(models.Model):
         "hr.contract",
         compute="_compute_last_contract_id",
         store=True,
+        prefetch=False,
         string="Last Contract",
         help="Last contract of the employee",
     )
     service_start_date = fields.Date(
-        string="Start Date", readonly=True, related="first_contract_id.date_start",
+        string="Start Date",
+        readonly=True,
+        related="first_contract_id.date_start",
+        prefetch=False,
     )
     service_termination_date = fields.Date(
-        string="Termination Date", readonly=True, related="last_contract_id.date_end",
+        string="Termination Date",
+        readonly=True,
+        related="last_contract_id.date_end",
+        prefetch=False,
     )
 
     @api.depends("contract_ids", "contract_ids.state", "contract_ids.date_start")


### PR DESCRIPTION
Without this change, an error is raised if a non HR user creates a leave, as it replaces hr.employee by hr.employee.public, but it cannot read this fields.

@OCA/human-resources-maintainers 