### PR TITLE
[10.0][IMP] hr_attendance_rfid: mark attendances posted by rfid

### DIFF
--- a/hr_attendance_rfid/__manifest__.py
+++ b/hr_attendance_rfid/__manifest__.py
@@ -19,6 +19,7 @@
     ],
     'data': [
         'views/hr_employee_view.xml',
+        'views/hr_attendance_view.xml',
         'security/hr_attendance_rfid.xml',
         'security/ir.model.access.csv',
     ],

--- a/hr_attendance_rfid/models/__init__.py
+++ b/hr_attendance_rfid/models/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
+from . import hr_attendance
 from . import hr_employee

--- a/hr_attendance_rfid/models/hr_attendance.py
+++ b/hr_attendance_rfid/models/hr_attendance.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 ForgeFlow S.L.
+
+from odoo import fields, models
+
+
+class HrAttendance(models.Model):
+    _inherit = "hr.attendance"
+
+    is_check_in_rfid = fields.Boolean()
+    is_check_out_rfid = fields.Boolean()

--- a/hr_attendance_rfid/models/hr_employee.py
+++ b/hr_attendance_rfid/models/hr_employee.py
@@ -56,8 +56,10 @@ class HrEmployee(models.Model):
                 res['logged'] = True
                 if attendance.check_out:
                     res['action'] = 'check_out'
+                    attendance.is_check_out_rfid = True
                 else:
                     res['action'] = 'check_in'
+                    attendance.is_check_in_rfid = True
                 return res
             else:
                 msg = _('No attendance was recorded for '

--- a/hr_attendance_rfid/views/hr_attendance_view.xml
+++ b/hr_attendance_rfid/views/hr_attendance_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_attendance_tree" model="ir.ui.view">
+        <field name="name">hr.attendance.tree</field>
+        <field name="model">hr.attendance</field>
+        <field name="inherit_id" ref="hr_attendance.view_attendance_tree"/>
+        <field name="priority">400</field>
+        <field name="arch" type="xml">
+            <field name="check_in" position="before">
+                <field name="is_check_in_rfid" invisible="1" />
+                <button icon="fa-check-circle" attrs="{'invisible': [('is_check_in_rfid', '=', False)]}"/>
+            </field>
+            <field name="check_out" position="before">
+                <field name="is_check_out_rfid" invisible="1" />
+                <button icon="fa-check-circle" attrs="{'invisible': [('is_check_out_rfid', '=', False)]}"/>
+            </field>
+            <xpath expr="//tree" position="attributes">
+                <attribute name="decoration-danger">is_check_in_rfid == False or is_check_out_rfid == False</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Mark the attendances created by rfid. I added too icons in the tree view (one for check_in, the other for the check_out). Also I added a decorator that checks both check_in and check_out are created by rfid.

If the solution is not ok for the community I will propose a hook instead so third module can make slight modifications.

cc@ForgeFlow