### PR TITLE
[IMP] hr_employee_calendar_planning: Define calendar in N employees

### DIFF
--- a/hr_employee_calendar_planning/__init__.py
+++ b/hr_employee_calendar_planning/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizards
 from .hooks import post_init_hook

--- a/hr_employee_calendar_planning/__manifest__.py
+++ b/hr_employee_calendar_planning/__manifest__.py
@@ -2,14 +2,18 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Employee Calendar Planning",
-    "version": "14.0.1.2.0",
+    "version": "14.0.2.0.0",
     "category": "Human Resources",
     "website": "https://github.com/OCA/hr",
     "author": "Tecnativa,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
     "depends": ["hr"],
-    "data": ["security/ir.model.access.csv", "views/hr_employee_views.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/hr_employee_views.xml",
+        "wizards/wizard_generate_calendar_planning.xml",
+    ],
     "post_init_hook": "post_init_hook",
     "maintainers": ["victoralmau", "pedrobaeza"],
 }

--- a/hr_employee_calendar_planning/security/ir.model.access.csv
+++ b/hr_employee_calendar_planning/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hr_employee_calendar_planning_user,access_hr_employee_calendar,model_hr_employee_calendar,base.group_user,1,0,0,0
 access_hr_employee_calendar_planning_manager,access_hr_employee_calendar,model_hr_employee_calendar,hr.group_hr_user,1,1,1,1
+access_wizard_generate_calendar_planning,access_wizard_generate_calendar_planning,model_wizard_generate_calendar_planning,hr.group_hr_user,1,1,1,1

--- a/hr_employee_calendar_planning/wizards/__init__.py
+++ b/hr_employee_calendar_planning/wizards/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import wizard_generate_calendar_planning

--- a/hr_employee_calendar_planning/wizards/wizard_generate_calendar_planning.py
+++ b/hr_employee_calendar_planning/wizards/wizard_generate_calendar_planning.py
@@ -1,0 +1,42 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class WizardGenerateCalendarPlanning(models.TransientModel):
+    _name = "wizard.generate.calendar.planning"
+    _description = (
+        "Generation wizard to allow generate calendar planning for N employees"
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        active_id = self._context.get("active_id")
+        active_ids = self._context.get("active_ids")
+        active_model = self._context.get("active_model")
+
+        if not active_ids or active_model != "hr.employee":
+            return res
+        res["employee_id"] = active_id
+        res["employee_ids"] = [(6, 0, active_ids)]
+        return res
+
+    calendar_ids = fields.Many2many(
+        comodel_name="hr.employee.calendar",
+        string="Calendar planning",
+    )
+    employee_id = fields.Many2one(
+        comodel_name="hr.employee",
+        string="Employee",
+    )
+    employee_ids = fields.Many2many(comodel_name="hr.employee", string="Employees")
+
+    def create_calendar_planning(self):
+        for employee in self.employee_ids - self.employee_id:
+            for calendar in self.calendar_ids:
+                calendar.copy(
+                    {
+                        "employee_id": employee.id,
+                    }
+                )

--- a/hr_employee_calendar_planning/wizards/wizard_generate_calendar_planning.xml
+++ b/hr_employee_calendar_planning/wizards/wizard_generate_calendar_planning.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="wizard_generate_calendar_planning_form_view">
+        <field name="name">wizard.generate.calendar.planning.form.view</field>
+        <field name="model">wizard.generate.calendar.planning</field>
+        <field name="arch" type="xml">
+            <form string="Generate Calendar Planning">
+                <group>
+                    <field name="employee_id" invisible="1" />
+                </group>
+                <group colspan="4">
+                    <separator string="Calendar Planning" colspan="4" />
+                    <newline />
+                    <field
+                        name="calendar_ids"
+                        context="{'default_employee_id': employee_id}"
+                        nolabel="1"
+                        widget="one2many"
+                    >
+                        <tree editable="bottom">
+                            <field name="company_id" invisible="1" />
+                            <field name="employee_id" invisible="1" />
+                            <field name="date_start" />
+                            <field name="date_end" />
+                            <field name="calendar_id" />
+                        </tree>
+                    </field>
+                </group>
+                <group colspan="4">
+                    <separator string="Employees" colspan="4" />
+                    <newline />
+                    <field name="employee_ids" nolabel="1" />
+                </group>
+                <footer>
+                    <button
+                        name="create_calendar_planning"
+                        string="Generate"
+                        class="btn-primary"
+                        type="object"
+                    />
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record
+        model="ir.actions.act_window"
+        id="wizard_generate_calendar_planning_act_window"
+    >
+        <field name="name">Generate Calendar Planning</field>
+        <field name="res_model">wizard.generate.calendar.planning</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="wizard_generate_calendar_planning_form_view" />
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="hr.model_hr_employee" />
+    </record>
+</odoo>


### PR DESCRIPTION
Now was added a wizard that allow define the same calendar planning for
N employees.

This is very common when the company has employees in the same group
and assign the same planning for all the group.