### PR TITLE
[FIX] hr_employee_calendar_planning: Avoid error with parent

### DIFF
--- a/hr_employee_calendar_planning/views/hr_employee_views.xml
+++ b/hr_employee_calendar_planning/views/hr_employee_views.xml
@@ -10,10 +10,7 @@
                 <attribute name="invisible">1</attribute>
             </field>
             <field name="resource_calendar_id" position="after">
-                <field
-                    name="calendar_ids"
-                    context="{'default_company_id': parent.company_id}"
-                >
+                <field name="calendar_ids" context="{'default_company_id': company_id}">
                     <tree editable="top">
                         <field name="company_id" invisible="1" />
                         <field name="date_start" />


### PR DESCRIPTION
Parent is not necessary on context, this returns the next error when you
try to select a calendar planning on the employee:
``Uncaught Error: NameError: name 'parent' is not defined``

![Screen Shot 2021-10-26 at 14 00 15](https://user-images.githubusercontent.com/7606656/138944123-28488ec7-90e7-4762-8d23-3501aa8e2a55.png)
