### PR TITLE
[12.0][FIX] hr_holidays_public: Remove existing link with meeting

### DIFF
--- a/hr_holidays_public/wizards/holidays_public_next_year_wizard.py
+++ b/hr_holidays_public/wizards/holidays_public_next_year_wizard.py
@@ -106,6 +106,7 @@ class HolidaysPublicNextYearWizard(models.TransientModel):
             new_vals = {
                 'year_id': new_calendar.id,
                 'date': fields.Date.to_string(date),
+                'meeting_id': False,
             }
             line.copy(new_vals)
 
@@ -114,6 +115,7 @@ class HolidaysPublicNextYearWizard(models.TransientModel):
                 'year_id': new_calendar.id,
                 'name': line.name,
                 'date': line.date,
+                'meeting_id': False,
             }
             line.line_id.copy(new_vals)
 


### PR DESCRIPTION
Otherwise new holidays dates will overwrite existing meetings dates