### PR TITLE
[12.0][FIX] hr_calendar_rest_time: Remove offending `all_day` value

### DIFF
--- a/hr_calendar_rest_time/__manifest__.py
+++ b/hr_calendar_rest_time/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'HR Calendar Rest Time',
     'summary': """
         Adds rest time to the calendar attendance records.""",
-    'version': '12.0.1.0.1',
+    'version': '12.0.2.0.0',
     'license': 'AGPL-3',
     'author': 'Creu Blanca, Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/hr',

--- a/hr_calendar_rest_time/migrations/12.0.2.0.0/pre-migration.py
+++ b/hr_calendar_rest_time/migrations/12.0.2.0.0/pre-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Regularize the period value to morning."""
+    openupgrade.logged_query(
+        env.cr,
+        """UPDATE resource_calendar_attendance
+        SET day_period = 'morning'
+        WHERE day_period = 'all_day'""",
+    )

--- a/hr_calendar_rest_time/models/resource_calendar_attendance.py
+++ b/hr_calendar_rest_time/models/resource_calendar_attendance.py
@@ -9,7 +9,6 @@ class ResourceCalendarAttendance(models.Model):
 
     _inherit = 'resource.calendar.attendance'
 
-    day_period = fields.Selection(selection_add=[('all_day', 'All Day')])
     rest_time = fields.Float(string='Rest Time')
 
     @api.onchange('rest_time')
@@ -17,8 +16,6 @@ class ResourceCalendarAttendance(models.Model):
         # avoid negative or after midnight
         self.rest_time = min(self.rest_time, 23.99)
         self.rest_time = max(self.rest_time, 0.0)
-        if self.rest_time:
-            self.day_period = 'all_day'
 
     @api.constrains('hour_from', 'hour_to', 'rest_time')
     def _check_rest_time(self):

--- a/hr_calendar_rest_time/tests/test_hr_calendar_rest_time.py
+++ b/hr_calendar_rest_time/tests/test_hr_calendar_rest_time.py
@@ -55,4 +55,3 @@ class HRCalendarRestTime(TransactionCase):
 
         self.calendar.attendance_ids[0].write({'rest_time': 2})
         self.calendar.attendance_ids[0]._onchange_rest_time()
-        self.assertEqual(self.calendar.attendance_ids[0].day_period, 'all_day')


### PR DESCRIPTION
This new day period doesn't make too much sense, as you can have a rest on morning and on afternoon, and introducing the new value may break other flows like requesting half-day leave.

We remove such custom value and regularize the existing calendar attendances to `morning`.

TT33794