### PR TITLE
[FIX] hr_personal_equipment_stock: change manifest url

### DIFF
--- a/hr_personal_equipment_stock/__manifest__.py
+++ b/hr_personal_equipment_stock/__manifest__.py
@@ -8,7 +8,7 @@
     "version": "13.0.1.0.0",
     "license": "AGPL-3",
     "author": "Creu Blanca,Odoo Community Association (OCA)",
-    "website": "www.creublanca.es",
+    "website": "https://github.com/OCA/hr",
     "depends": ["hr_personal_equipment_request", "stock"],
     "data": [
         "views/stock_location.xml",


### PR DESCRIPTION
This PR fixes the Url of the manifest to include the standard OCA url