### PR TITLE
[14.0][FIX] hr_employee_calendar_planning: Regenerate automatic calendar 2 weeks.

### DIFF
--- a/hr_employee_calendar_planning/__manifest__.py
+++ b/hr_employee_calendar_planning/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Employee Calendar Planning",
-    "version": "14.0.1.2.0",
+    "version": "14.0.1.3.0",
     "category": "Human Resources",
     "website": "https://github.com/OCA/hr",
     "author": "Tecnativa,Odoo Community Association (OCA)",

--- a/hr_employee_calendar_planning/migrations/14.0.1.3.0/post-migration.py
+++ b/hr_employee_calendar_planning/migrations/14.0.1.3.0/post-migration.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["hr.employee"].with_context(active_test=False).search([]).filtered(
+        lambda x: any(c.calendar_id.two_weeks_calendar for c in x.calendar_ids)
+        and any(not c.calendar_id.two_weeks_calendar for c in x.calendar_ids)
+    ).regenerate_calendar()

--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -72,45 +72,38 @@ class HrEmployee(models.Model):
             self.resource_calendar_id.attendance_ids.unlink()
             self.resource_calendar_id.two_weeks_calendar = two_weeks
         seq = 0
-        for line in self.calendar_ids:
-            for attendance_line in line.calendar_id.attendance_ids:
-                if attendance_line.display_type == "line_section":
-                    continue
-                duplicate = two_weeks and not line.calendar_id.two_weeks_calendar
-                week_odd = attendance_line.week_type == "1"
-                data = attendance_line.copy_data(
-                    {
-                        "calendar_id": self.resource_calendar_id.id,
-                        "date_from": line.date_start,
-                        "date_to": line.date_end,
-                        "week_type": "0" if duplicate else attendance_line.week_type,
-                        "sequence": seq + 26 if week_odd else 24 - seq,
-                        # To make sure sequence of odd weeks is greater than 25
-                        # and sequence of even weeks is less than 25, as in
-                        # /resource/models/resource.py#L266
-                    }
-                )[0]
+        for week in ["0", "1"] if two_weeks else ["0"]:
+            if two_weeks:
+                section_vals = SECTION_LINES[int(week)]
+                section_vals[2]["sequence"] = seq
+                vals_list.append(section_vals)
                 seq += 1
-                vals_list.append((0, 0, data))
-                if duplicate:
+            for line in self.calendar_ids:
+                if line.calendar_id.two_weeks_calendar:
+                    attendances = line.calendar_id.attendance_ids.filtered(
+                        lambda x: x.week_type == week
+                    )
+                else:
+                    attendances = line.calendar_id.attendance_ids
+                for attendance_line in attendances:
+                    if attendance_line.display_type == "line_section":
+                        continue
                     data = attendance_line.copy_data(
                         {
                             "calendar_id": self.resource_calendar_id.id,
                             "date_from": line.date_start,
                             "date_to": line.date_end,
-                            "week_type": "1",
-                            "sequence": seq + 26,
-                        },
+                            "week_type": week if two_weeks else False,
+                            "sequence": seq,
+                        }
                     )[0]
                     seq += 1
-                    vals_list += [(0, 0, data)]
-        if two_weeks:
-            SECTION_LINES[0][2]["sequence"] = -seq
-            vals_list = SECTION_LINES + vals_list
+                    vals_list.append((0, 0, data))
         self.resource_calendar_id.attendance_ids = vals_list
 
     def regenerate_calendar(self):
-        self._regenerate_calendar()
+        for item in self:
+            item._regenerate_calendar()
 
 
 class HrEmployeeCalendar(models.Model):

--- a/hr_employee_calendar_planning/static/description/index.html
+++ b/hr_employee_calendar_planning/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Employee Calendar Planning</title>
 <style type="text/css">
 

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -344,3 +344,18 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
         company2 = self.env["res.company"].create({"name": "Test company"})
         with self.assertRaises(exceptions.ValidationError):
             self.calendar1.company_id = company2
+
+    def test_employee_with_calendar_ids(self):
+        employee = self.env["hr.employee"].create(
+            {
+                "name": "Test employee",
+                "calendar_ids": [
+                    (
+                        0,
+                        0,
+                        {"date_start": "2020-01-01", "calendar_id": self.calendar2.id},
+                    ),
+                ],
+            }
+        )
+        self.assertTrue(employee.resource_calendar_id.auto_generate)

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -11,7 +11,7 @@ from ..hooks import post_init_hook
 class TestHrEmployeeCalendarPlanning(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
-        super(TestHrEmployeeCalendarPlanning, cls).setUpClass()
+        super().setUpClass()
         resource_calendar = cls.env["resource.calendar"]
         cls.calendar1 = resource_calendar.create(
             {"name": "Test calendar 1", "attendance_ids": []}
@@ -143,6 +143,155 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
         self.assertEqual(
             len(self.employee.resource_calendar_id.attendance_ids), 20 + 6 * 2 + 2
         )
+
+    def test_calendar_planning_two_weeks(self):
+        self.calendar1.switch_calendar_type()
+        self.employee.calendar_ids = [
+            (0, 0, {"date_end": "2019-12-31", "calendar_id": self.calendar1.id}),
+            (0, 0, {"date_start": "2020-01-01", "calendar_id": self.calendar2.id}),
+        ]
+        self.assertEqual(
+            len(self.employee.resource_calendar_id.attendance_ids), 20 + 5 * 2 + 2
+        )
+        items = self.employee.resource_calendar_id.attendance_ids
+        items_with_sections = items.filtered(lambda x: x.display_type)
+        self.assertEqual(len(items_with_sections), 2)
+        items_date_to = items.filtered(
+            lambda x: x.date_to == fields.Date.to_date("2019-12-31")
+        )
+        self.assertEqual(len(items_date_to), 20)
+        self.assertEqual(len(items_date_to.filtered(lambda x: x.week_type == "0")), 10)
+        self.assertEqual(len(items_date_to.filtered(lambda x: x.week_type == "1")), 10)
+        items_date_from = items.filtered(
+            lambda x: x.date_from == fields.Date.to_date("2020-01-01")
+        )
+        self.assertEqual(len(items_date_from), 10)
+        self.assertEqual(len(items_date_from.filtered(lambda x: x.week_type == "0")), 5)
+        self.assertEqual(len(items_date_from.filtered(lambda x: x.week_type == "1")), 5)
+        items_without_sections = items - items_with_sections
+        self.assertEqual(
+            len(items_without_sections.filtered(lambda x: x.week_type == "0")), 10 + 5
+        )
+        self.assertEqual(
+            len(items_without_sections.filtered(lambda x: x.week_type == "1")), 10 + 5
+        )
+        self.calendar2.switch_calendar_type()
+        items = self.employee.resource_calendar_id.attendance_ids
+        items_with_sections = items.filtered(lambda x: x.display_type)
+        items_without_sections = items - items_with_sections
+        self.assertEqual(len(items), 20 + 20 + 2)
+        self.assertEqual(len(items_with_sections), 2)
+        items_date_to = items.filtered(
+            lambda x: x.date_to == fields.Date.to_date("2019-12-31")
+        )
+        self.assertEqual(len(items_date_to), 20)
+        items_date_from = items.filtered(
+            lambda x: x.date_from == fields.Date.to_date("2020-01-01")
+        )
+        self.assertEqual(len(items_date_from), 20)
+        items_week_0 = items_without_sections.filtered(lambda x: x.week_type == "0")
+        self.assertEqual(len(items_week_0), 10 + 10)
+        self.assertEqual(
+            len(
+                items_week_0.filtered(
+                    lambda x: x.date_to == fields.Date.to_date("2019-12-31")
+                )
+            ),
+            5 + 5,
+        )
+        self.assertEqual(
+            len(
+                items_week_0.filtered(
+                    lambda x: x.date_from == fields.Date.to_date("2020-01-01")
+                )
+            ),
+            5 + 5,
+        )
+        items_week_1 = items_without_sections.filtered(lambda x: x.week_type == "1")
+        self.assertEqual(len(items_week_1), 10 + 10)
+        self.assertEqual(
+            len(
+                items_week_1.filtered(
+                    lambda x: x.date_to == fields.Date.to_date("2019-12-31")
+                )
+            ),
+            5 + 5,
+        )
+        self.assertEqual(
+            len(
+                items_week_1.filtered(
+                    lambda x: x.date_from == fields.Date.to_date("2020-01-01")
+                )
+            ),
+            5 + 5,
+        )
+
+    def test_calendar_planning_two_weeks_multi(self):
+        self.calendar1.switch_calendar_type()
+        self.calendar2.switch_calendar_type()
+        self.employee.calendar_ids = [
+            (0, 0, {"date_end": "2019-12-31", "calendar_id": self.calendar1.id}),
+            (
+                0,
+                0,
+                {
+                    "date_start": "2020-01-01",
+                    "date_end": "2020-01-31",
+                    "calendar_id": self.calendar2.id,
+                },
+            ),
+            (
+                0,
+                0,
+                {
+                    "date_start": "2020-02-01",
+                    "date_end": "2020-02-02",
+                    "calendar_id": self.calendar1.id,
+                },
+            ),
+            (0, 0, {"date_start": "2020-01-03", "calendar_id": self.calendar2.id}),
+        ]
+        items = self.employee.resource_calendar_id.attendance_ids
+        items_with_sections = items.filtered(lambda x: x.display_type)
+        items_without_sections = items - items_with_sections
+        self.assertEqual(len(items), (20 * 2) + (20 * 2) + 2)
+        self.assertEqual(len(items_with_sections), 2)
+        items_week_0 = items_without_sections.filtered(lambda x: x.week_type == "0")
+        self.assertEqual(
+            len(
+                items_week_0.filtered(
+                    lambda x: x.date_to == fields.Date.to_date("2019-12-31")
+                )
+            ),
+            10,
+        )
+        self.assertEqual(
+            len(
+                items_week_0.filtered(
+                    lambda x: x.date_to == fields.Date.to_date("2020-01-31")
+                )
+            ),
+            10,
+        )
+        self.assertEqual(
+            len(
+                items_week_0.filtered(
+                    lambda x: x.date_to == fields.Date.to_date("2020-02-02")
+                )
+            ),
+            10,
+        )
+        self.assertEqual(
+            len(
+                items_week_0.filtered(
+                    lambda x: x.date_from == fields.Date.to_date("2020-01-03")
+                )
+            ),
+            10,
+        )
+        self.assertEqual(len(items_week_0), 20 + 20)
+        items_week_1 = items_without_sections.filtered(lambda x: x.week_type == "1")
+        self.assertEqual(len(items_week_0), len(items_week_1))
 
     def test_post_install_hook(self):
         self.employee.resource_calendar_id = self.calendar1.id


### PR DESCRIPTION
Regenerate automatic calendar correctly when calendars are 2 weeks old (or any of them are 2 weeks old).

FWP from 13.0: https://github.com/OCA/hr/pull/1035

Steps to reproduce:
- Define several calendar planning in an employee.
- The calendars must be of type 2 weeks (or at least one of them).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT32425