### PR TITLE
[12.0][FIX] hr_employee_calendar_planning: Regenerate the automatic calendar if calendars have been defined in employee creation.

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -40,6 +40,13 @@ class HrEmployee(models.Model):
     def regenerate_calendar(self):
         self._regenerate_calendar()
 
+    @api.model
+    def create(self, vals):
+        record = super(HrEmployee, self).create(vals)
+        if record.calendar_ids:
+            record.regenerate_calendar()
+        return record
+
 
 class HrEmployeeCalendar(models.Model):
     _name = 'hr.employee.calendar'

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -125,3 +125,18 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
         self.assertEqual(
             len(self.employee.calendar_ids[1].calendar_id.attendance_ids), 8,
         )
+
+    def test_employee_with_calendar_ids(self):
+        employee = self.env["hr.employee"].create(
+            {
+                "name": "Test employee",
+                "calendar_ids": [
+                    (
+                        0,
+                        0,
+                        {"date_start": "2020-01-01", "calendar_id": self.calendar2.id},
+                    ),
+                ],
+            }
+        )
+        self.assertTrue(employee.resource_calendar_id.auto_generate)


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/hr/pull/1035

Regenerate the automatic calendar if calendars have been defined in employee creation.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT32425