### PR TITLE
[13.0][FIX] resource_hook: Avoid crash when validating leaves

### DIFF
--- a/resource_hook/hooks.py
+++ b/resource_hook/hooks.py
@@ -173,7 +173,7 @@ def post_load_hook():  # noqa: C901
         )[resource.id]
         result = defaultdict(float)
         for start, stop, meta in intervals:
-            result[start.date()] += self._get_work_hours_interval(start, stop, meta)
+            result[start.date()] += calendar._get_work_hours_interval(start, stop, meta)
         return sorted(result.items())
 
     def __new_list_leaves(self, from_datetime, to_datetime, calendar=None, domain=None):


### PR DESCRIPTION
    Fix the validation of leaves
    
    With module resource_hook installed the method
    _get_work_hours_interval(start, stop, meta)
    is called from a hr.employee (self) Object.
    This is not implemented for hr.employee unless you do it by yourself
    and Odoo crashes on second Approve.
    Since a calendar object exists you can use calendar instead of self.