### PR TITLE
[13.0][FIX] hr_personal_equipment_stock: fix partner_id and origin wh…

### DIFF
--- a/hr_personal_equipment_stock/models/hr_personal_equipment.py
+++ b/hr_personal_equipment_stock/models/hr_personal_equipment.py
@@ -98,8 +98,8 @@ class HrPersonalEquipment(models.Model):
                     allocation.quantity,
                     allocation.product_uom_id,
                     allocation.location_id,
-                    allocation.name,
-                    allocation.name,
+                    allocation.equipment_request_id.name,
+                    allocation.equipment_request_id.name,
                     allocation._get_company(),
                     values,
                 )


### PR DESCRIPTION
…en creating stock.picking

When a personal equipment request was done with more than one allocation, the picking did not have partner_id, nor origin. The reason was that stock moves did not have the same origin, as it was set the name of the allocation, instead of the name of the personal equipment request. This commit solves this issue.