### PR TITLE
[FIX] hr_holidays_public: use tz.localize instead datetime.replace

### DIFF
--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -43,14 +43,14 @@ class ResourceCalendar(models.Model):
             for line in lines:
                 leaves.append(
                     (
-                        datetime.combine(
+                        tz.localize(datetime.combine(
                             line.date,
                             time.min
-                        ).replace(tzinfo=tz),
-                        datetime.combine(
+                        )),
+                        tz.localize(datetime.combine(
                             line.date,
                             time.max
-                        ).replace(tzinfo=tz),
+                        )),
                         self.env['resource.calendar.leaves']
                     ),
                 )


### PR DESCRIPTION
Using datetime.replace to set timezone to naive datetime objects
results in historical timezone offset, not the one in effect for the
given date.

For example:

```
tz = timezone('Europe/Tallinn')
datetime.now().replace(tzinfo=tz)  # LMT+1:39:00
tz.localize(datetime.now())  # EET+2:00:00
```

@see: https://stackoverflow.com/questions/13994594/how-to-add-timezone-into-a-naive-datetime-instance-in-python/13994611#13994611