### PR TITLE
[14.0][FIX] hr_employee_calendar_planning: Avoid error with parent

### DIFF
--- a/hr_employee_calendar_planning/views/hr_employee_views.xml
+++ b/hr_employee_calendar_planning/views/hr_employee_views.xml
@@ -10,10 +10,7 @@
                 <attribute name="invisible">1</attribute>
             </field>
             <field name="resource_calendar_id" position="after">
-                <field
-                    name="calendar_ids"
-                    context="{'default_company_id': parent.company_id}"
-                >
+                <field name="calendar_ids" context="{'default_company_id': company_id}">
                     <tree editable="top">
                         <field name="company_id" invisible="1" />
                         <field name="date_start" />


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/hr/pull/1045

Parent is not necessary on context, this returns the next error when you
try to select a calendar planning on the employee:
``Uncaught Error: NameError: name 'parent' is not defined``

Please @pedrobaeza can you review it?

@Tecnativa