### PR TITLE
[14.0][IMP] hr_employee_ppe product_template view

### DIFF
--- a/hr_employee_ppe/views/product_template.xml
+++ b/hr_employee_ppe/views/product_template.xml
@@ -26,12 +26,12 @@
                     <field
                         name="ppe_duration"
                         string="PPE Duration"
-                        attrs="{'invisible': [('expirable_ppe', '=', False)], 'required': [('expirable_ppe', '!=', False)]}"
+                        attrs="{'invisible': ['|', ('expirable_ppe', '=', False), ('is_ppe', '=', False)], 'required': [('expirable_ppe', '!=', False), ('is_ppe', '!=', False)]}"
                     />
                     <field
                         name="ppe_interval_type"
                         string="PPE Interval Type"
-                        attrs="{'invisible': [('expirable_ppe', '=', False)], 'required': [('expirable_ppe', '!=', False)]}"
+                        attrs="{'invisible': ['|', ('expirable_ppe', '=', False), ('is_ppe', '=', False)], 'required': [('expirable_ppe', '!=', False), ('is_ppe', '!=', False)]}"
                     />
                 </group>
             </page>


### PR DESCRIPTION
When you mark is_ppe and expirable_ppe checks, and then you unmark is_ppe, ppe_duration and ppe_interval_type remain visible and required.
This changes fixes this error