### PR TITLE
[IMP] hr_attendance_report_theoretical_time: department record rule

### DIFF
--- a/hr_attendance_report_theoretical_time/security/hr_attendance_report_theoretical_time_security.xml
+++ b/hr_attendance_report_theoretical_time/security/hr_attendance_report_theoretical_time_security.xml
@@ -7,7 +7,7 @@
         <field name="name">Theoretical vs worked hours: Own attendances</field>
         <field name="model_id" ref="model_hr_attendance_theoretical_time_report"/>
         <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance'))]"/>
-        <field name="domain_force">[['employee_id.user_id', '=', user.id]]</field>
+        <field name="domain_force">['|', ['employee_id.user_id', '=', user.id], ['employee_id.parent_id.user_id', '=', user.id]]</field>
     </record>
 
     <record model="ir.rule" id="rule_theoretical_vs_worked_report_all">


### PR DESCRIPTION
Department responsibles should be able to check their subordinates theoretical hours reports.

cc @Tecnativa TT38378

please review @victoralmau @pedrobaeza 