### PR TITLE
[12.0][FIX] hr_expense_invoice: Change _validate_expense_invoice() function to use amount_total from invoices.

### DIFF
--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -56,7 +56,7 @@ class HrExpenseSheet(models.Model):
         if any(invoices.filtered(lambda i: i.state != 'open')):
             raise UserError(_('Vendor bill state must be Open'))
         expense_amount = sum(expense_lines.mapped('total_amount'))
-        invoice_amount = sum(invoices.mapped('residual'))
+        invoice_amount = sum(invoices.mapped('amount_total'))
         # Expense amount must equal invoice amount
         if float_compare(expense_amount, invoice_amount, precision) != 0:
             raise UserError(


### PR DESCRIPTION
Change `_validate_expense_invoice()` function to use amount_total from invoices.

If residual amount from invoice is not the same, it should not show an error.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40175