### PR TITLE
[14.0][IMP] hr_employee_calendar_planning: Hide resource_calendar_id field from employee public form view

### DIFF
--- a/hr_employee_calendar_planning/views/hr_employee_views.xml
+++ b/hr_employee_calendar_planning/views/hr_employee_views.xml
@@ -21,4 +21,14 @@
             </field>
         </field>
     </record>
+    <record id="hr_employee_public_view_form" model="ir.ui.view">
+        <field name="name">hr.employee.public.form</field>
+        <field name="model">hr.employee.public</field>
+        <field name="inherit_id" ref="hr.hr_employee_public_view_form" />
+        <field name="arch" type="xml">
+            <field name="resource_calendar_id" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/hr/pull/1147

Hide `resource_calendar_id` field from employee public form view

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT40038