### PR TITLE
[FIX] hr_employee_calendar_planning: no constraint on install mode

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -157,6 +157,7 @@ class HrEmployee(models.Model):
         if (
             not self.env.context.get("skip_employee_calendars_required")
             and not config["test_enable"]
+            and not self.env.context.get("install_mode")
             and res.filtered(lambda x: not x.calendar_ids)
         ):
             raise UserError(_("You can not create employees without any calendar."))


### PR DESCRIPTION
When another module was installed with demo data but without testing mode, if the demo data includes some `hr.employee` record, it was impossible to install it after `hr_employee_calendar_planning` was installed.

@moduon MT-1622