### PR TITLE
[14.0][FIX] hr_employee_calendar_planning: prevent loop

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -106,11 +106,11 @@ class HrEmployee(models.Model):
             self.resource_calendar_id.attendance_ids = vals_list
         # Set the hours per day to the last (top date end) calendar line to apply
         if self.calendar_ids:
-            self.resource_calendar_id.hours_per_day = self.calendar_ids[
+            self.resource_id.calendar_id.hours_per_day = self.calendar_ids[
                 0
             ].calendar_id.hours_per_day
             # set global leaves
-            self.resource_calendar_id.global_leave_ids = [
+            self.resource_id.calendar_id.global_leave_ids = [
                 (
                     6,
                     0,


### PR DESCRIPTION
When creating a new employee, the regenerate_calendar method creates a new auto-generated calendar and assigns it to the resource_id.calendar_id field. However, the global_leave_ids and hours_per_day are written to the resource_calendar_id field. Even though resource_calendar_id and resource_id.calendar_id are related fields due to the resource.mixin model, the method initially edits the wrong (original) calendar instead of the auto-generated calendar. This triggers the write method in the resource.calendar model, which again calls regenerate_calendar, thus creating a loop.
By writing global_leaves and hours_per_day into resource_id.calendar_id, the correct (auto-generated) calendar is edited, preventing the loop.