### PR TITLE
FIX: hr_job_category removes employee tags that are not into the contract

### DIFF
--- a/hr_job_category/models/hr.py
+++ b/hr_job_category/models/hr.py
@@ -59,12 +59,13 @@ class HRContract(models.Model):
 
     def write(self, vals):
         prev_data = self.read(["job_id"])
-
+        if "employee_id" in vals and self.employee_id != vals.get("employee_id"):
+            self._remove_tags(self.employee_id.id, self.job_id.id)
         res = super().write(vals)
-
         # Go through each record and delete tags associated with the previous
         # job, then add the tags of the new job.
         #
+
         for contract in self:
             for data in prev_data:
                 if (

--- a/hr_job_category/models/hr.py
+++ b/hr_job_category/models/hr.py
@@ -23,16 +23,32 @@ class HRJob(models.Model):
 class HRContract(models.Model):
     _inherit = "hr.contract"
 
-    def _tag_employees(self, job_id):
-        if job_id:
-            job = self.env["hr.job"].browse(job_id)
-            self.mapped("employee_id").write(
-                {"category_ids": [(6, 0, job.category_ids.ids)]}
-            )
-        else:
-            for contract in self:
-                categories = contract.job_id and contract.job_id.category_ids.ids or []
-                contract.employee_id.write({"category_ids": [(6, 0, categories)]})
+    def _remove_tags(self, employee_id=None, job_id=None):
+        # TODO write tags only once
+        if not employee_id or not job_id:
+            return
+        employee = self.env["hr.employee"].browse(employee_id)
+        empl_tags = employee.category_ids
+        job = self.env["hr.job"].browse(job_id)
+        _logger.debug(
+            "Removing employee tags if tag exists on contract " "job: %s", empl_tags
+        )
+        for tag in job.category_ids:
+            if tag in empl_tags:
+                employee.write({"category_ids": [(3, tag.id)]})
+
+    def _tag_employees(self, employee_id=None, job_id=None):
+        if not employee_id or not job_id:
+            return
+        employee = self.env["hr.employee"].browse(employee_id)
+        empl_tags = employee.category_ids
+        job = self.env["hr.job"].browse(job_id)
+        for tag in job.category_ids:
+            if tag not in empl_tags:
+                _logger.debug(
+                    "Adding employee tag if job tag doesn't " "exists: %s", tag.name
+                )
+                employee.write({"category_ids": [(4, tag.id)]})
 
     @api.model
     def create(self, vals):
@@ -42,13 +58,30 @@ class HRContract(models.Model):
         return res
 
     def write(self, vals):
-        if "employee_id" in vals:
-            self.mapped("employee_id").write({"category_ids": [(5,)]})
+        prev_data = self.read(["job_id"])
+
         res = super().write(vals)
-        if "job_id" in vals or ("employee_id" in vals and vals["employee_id"]):
-            self._tag_employees(vals.get("job_id"))
+
+        # Go through each record and delete tags associated with the previous
+        # job, then add the tags of the new job.
+        #
+        for contract in self:
+            for data in prev_data:
+                if (
+                    data.get("id") == contract.id
+                    and data["job_id"]
+                    and data["job_id"][0] != contract.job_id.id
+                ):
+                    self._remove_tags(contract.employee_id.id, data["job_id"][0])
+                self._tag_employees(contract.employee_id.id, contract.job_id.id)
         return res
 
     def unlink(self):
-        self.mapped("employee_id").write({"category_ids": [(5,)]})
-        return super().unlink()
+        prev_data = self.read(["job_id"])
+        # Go through each record and delete tags associated with the previous
+        # job, then add the tags of the new job.
+        #
+        for contract in self:
+            for data in prev_data:
+                self._remove_tags(contract.employee_id.id, data["job_id"][0])
+        return super(HRContract, self).unlink()

--- a/hr_job_category/models/hr.py
+++ b/hr_job_category/models/hr.py
@@ -37,18 +37,18 @@ class HRContract(models.Model):
             if tags_to_remove:
                 employee.write({"category_ids": tags_to_remove})
 
-    def _tag_employees(self, employee_id=None, job_id=None):
-        if not employee_id or not job_id:
-            return
-        employee = self.env["hr.employee"].browse(employee_id)
-        empl_tags = employee.category_ids
+    def _tag_employees(self, job_id):
         job = self.env["hr.job"].browse(job_id)
-        for tag in job.category_ids:
-            if tag not in empl_tags:
-                _logger.debug(
-                    "Adding employee tag if job tag doesn't " "exists: %s", tag.name
-                )
-                employee.write({"category_ids": [(4, tag.id)]})
+        _logger.debug(
+            "Adding employee tags if job tags doesn't exist: %s", job.category_ids
+        )
+        for employee in self.mapped("employee_id"):
+            tags_to_add = [
+                (4, tag.id)
+                for tag in job.category_ids - employee.category_ids
+            ]
+            if tags_to_add:
+                employee.write(tags_to_add)
 
     @api.model
     def create(self, vals):

--- a/hr_job_category/models/hr.py
+++ b/hr_job_category/models/hr.py
@@ -73,7 +73,7 @@ class HRContract(models.Model):
             job_id = prev_data.get(contract.id)
             if job_id:
                 contract._remove_tags(job_id)
-                self._tag_employees(contract.employee_id.id, contract.job_id.id)
+                self._tag_employees(contract.job_id.id)
         return res
 
     def unlink(self):

--- a/hr_job_category/models/hr.py
+++ b/hr_job_category/models/hr.py
@@ -70,13 +70,9 @@ class HRContract(models.Model):
         #
 
         for contract in self:
-            for data in prev_data:
-                if (
-                    data.get("id") == contract.id
-                    and data["job_id"]
-                    and data["job_id"][0] != contract.job_id.id
-                ):
-                    self._remove_tags(contract.employee_id.id, data["job_id"][0])
+            job_id = prev_data.get(contract.id)
+            if job_id:
+                contract._remove_tags(job_id)
                 self._tag_employees(contract.employee_id.id, contract.job_id.id)
         return res
 

--- a/hr_job_category/models/hr.py
+++ b/hr_job_category/models/hr.py
@@ -58,7 +58,10 @@ class HRContract(models.Model):
         return res
 
     def write(self, vals):
-        prev_data = self.read(["job_id"])
+        prev_data = {
+            res["id"]: res["job_id"][0]
+            for res in self.read(["job_id"]) if res["job_id"]
+        }
         if "employee_id" in vals and self.employee_id != vals.get("employee_id"):
             self._remove_tags(self.employee_id.id, self.job_id.id)
         res = super().write(vals)

--- a/hr_job_category/models/hr.py
+++ b/hr_job_category/models/hr.py
@@ -77,11 +77,13 @@ class HRContract(models.Model):
         return res
 
     def unlink(self):
-        prev_data = self.read(["job_id"])
-        # Go through each record and delete tags associated with the previous
-        # job, then add the tags of the new job.
-        #
+        prev_data = {
+            res["id"]: res["job_id"][0]
+            for res in self.read(["job_id"]) if res["job_id"]
+        }
+        # Go through each record and delete tags associated with the previous job
         for contract in self:
-            for data in prev_data:
-                self._remove_tags(contract.employee_id.id, data["job_id"][0])
-        return super(HRContract, self).unlink()
+            job_id = prev_data.get(contract.id)
+            if job_id:
+                contract._remove_tags(job_id)
+        return super().unlink()

--- a/hr_job_category/models/hr.py
+++ b/hr_job_category/models/hr.py
@@ -23,19 +23,19 @@ class HRJob(models.Model):
 class HRContract(models.Model):
     _inherit = "hr.contract"
 
-    def _remove_tags(self, employee_id=None, job_id=None):
-        # TODO write tags only once
-        if not employee_id or not job_id:
-            return
-        employee = self.env["hr.employee"].browse(employee_id)
-        empl_tags = employee.category_ids
+    def _remove_tags(job_id):
         job = self.env["hr.job"].browse(job_id)
-        _logger.debug(
-            "Removing employee tags if tag exists on contract " "job: %s", empl_tags
-        )
-        for tag in job.category_ids:
-            if tag in empl_tags:
-                employee.write({"category_ids": [(3, tag.id)]})
+        for employee in self.mapped("employee_id"):
+            _logger.debug(
+                "Removing employee tags if tags exist on contract job: %s",
+                employee.category_ids,
+            )
+            tags_to_remove = [
+                (3, tag.id)
+                for tag in job.category_ids & employee.category_ids
+            ]
+            if tags_to_remove:
+                employee.write({"category_ids": tags_to_remove})
 
     def _tag_employees(self, employee_id=None, job_id=None):
         if not employee_id or not job_id:

--- a/hr_job_category/tests/test_hr_job_categories.py
+++ b/hr_job_category/tests/test_hr_job_categories.py
@@ -73,7 +73,7 @@ class TestHrJobCategories(common.TransactionCase):
         # We need to force the job, as it is modified by a compute
         self.employee_id_1.refresh()
         self.employee_id_2.refresh()
-        # self.assertFalse(self.employee_id_1.category_ids)
+        self.assertFalse(self.employee_id_1.category_ids)
         self.job_2_id.refresh()
         self.assertTrue(
             all(

--- a/hr_job_category/tests/test_hr_job_categories.py
+++ b/hr_job_category/tests/test_hr_job_categories.py
@@ -81,3 +81,21 @@ class TestHrJobCategories(common.TransactionCase):
 
         self.contract_id.unlink()
         self.assertFalse(self.employee_id_2.category_ids)
+
+    def test_add_new_tags_with_already_present_tags(self):
+        """
+        When a tag is manually added, adding new tags from a contract shouldn't remove
+        them
+        """
+        categ_3_id = self.employee_categ_model.create({"name": "Category 3"})
+        self.employee_id_1.write({"category_ids": categ_3_id})
+        # We have added manually a tag
+        self.assertEquals(len(self.employee_id_1.category_ids.ids),1)
+        self.assertEquals(self.employee_id_1.category_ids.ids[0], categ_3_id.id)
+        # We are now adding contract with 1 job category
+        # The employee should now have two tags
+        self.contract_id.write({"job_id": self.job_id.id})
+        self.contract_id.refresh()
+        self.assertEquals(len(self.employee_id_1.category_ids.ids),2)
+        self.assertEquals(self.employee_id_1.category_ids.ids[0], categ_3_id.id)
+        self.assertEquals(self.employee_id_1.category_ids.ids[1], self.job_2_id.category_ids.ids[0])

--- a/hr_job_category/tests/test_hr_job_categories.py
+++ b/hr_job_category/tests/test_hr_job_categories.py
@@ -126,3 +126,19 @@ class TestHrJobCategories(common.TransactionCase):
         self.assertIn(
             self.job_2_id.category_ids.ids[0], self.employee_id_1.category_ids.ids
         )
+
+    def test_unlink_contract(self):
+        """When we unlink a contract, it should remove only the tags related to it"""
+        self.employee_id_1.write({"category_ids": self.categ_3_id})
+        self.contract_id.write({"job_id": self.job_id.id})
+        self.contract_id.refresh()
+
+        # We have two tags (from job and the manual added one)
+        self.assertEqual(len(self.employee_id_1.category_ids.ids), 2)
+
+        self.contract_id.unlink()
+        self.assertEqual(len(self.employee_id_1.category_ids.ids), 1)
+        self.assertIn(self.categ_3_id.id, self.employee_id_1.category_ids.ids)
+        self.assertNotIn(
+            self.job_id.category_ids.ids[0], self.employee_id_1.category_ids.ids
+        )


### PR DESCRIPTION
The module has been simplified during the migration 12.0 -> 13.0 https://github.com/OCA/hr/pull/895
Since this simplification contained a regression:
-  The employee tags are now stricly binded from the contracts & job positions
- Updating a contract would flush away all the existing tags

Tags on employee could come from distinct sources (manually added) or linked to other models.
We want to avoid this hard link.

For the moment, I only took back the code from 12.0 (with a small addition) which would require some optimizations.