### PR TITLE
[10.0][FIX] hr_payroll_cancel: reversal on the same date of the posting

### DIFF
--- a/hr_payroll_cancel/models/hr_payroll.py
+++ b/hr_payroll_cancel/models/hr_payroll.py
@@ -35,6 +35,6 @@ class HrPayslip(models.Model):
                 payslip.move_id.button_cancel()
                 payslip.move_id.unlink()
             else:
-                payslip.move_id.reverse_moves()
+                payslip.move_id.reverse_moves(date=payslip.move_id.date)
                 payslip.move_id = False
         return self.write({'state': 'cancel'})


### PR DESCRIPTION
if the pyaslip is posted again it will be posted on the same date so it makes sense to do the reversal on the same date

cc @ForgeFlow