### PR TITLE
[14.0][FIX] hr_employee_ppe: compute field contains PPE

### DIFF
--- a/hr_employee_ppe/models/hr_personal_equipment_request.py
+++ b/hr_employee_ppe/models/hr_personal_equipment_request.py
@@ -12,12 +12,12 @@ class HrPersonalEquipmentRequest(models.Model):
 
     def _compute_contains_ppe(self):
         for rec in self:
+            contains_ppe = False
             for line in rec.line_ids:
                 if line.is_ppe:
-                    rec.contains_ppe = True
-                    return
-                else:
-                    rec.contains_ppe = False
+                    contains_ppe = True
+                    break
+            rec.contains_ppe = contains_ppe
 
     def action_view_ppe_report(self):
         report = self.env["ir.actions.report"]._get_report_from_name(


### PR DESCRIPTION
Odoo show an error when you save personal equipment request without lines because `contains_ppe` field becomes empty.

![error_compute_field](https://user-images.githubusercontent.com/55379877/221920277-50f2b49e-1846-4876-9583-3dcfde48aa78.gif)
