### PR TITLE
[14.0] [IMP] hr_employee_service: Add helper function

### DIFF
--- a/hr_employee_service/models/hr_employee.py
+++ b/hr_employee_service/models/hr_employee.py
@@ -104,3 +104,21 @@ class HrEmployee(models.Model):
             return datetime.combine(service_start_date, time(0, 0, 0))
         else:
             return super()._get_date_start_work()
+
+    def get_service_duration_from_date(self, date=None):
+        """
+        Returns the employee service duration for the given date.
+        This function is used in OCA/payroll modules as a helper function
+        to calculate employee service duration calculated for the given date.
+        """
+        self.ensure_one()
+        if not date or not self.service_start_date:
+            return {"years": 0, "months": 0, "days": 0}
+        if date > self.service_start_date:
+            service_duration = relativedelta(date, self.service_start_date)
+            return {
+                "years": service_duration.years,
+                "months": service_duration.months,
+                "days": service_duration.days,
+            }
+        return {"years": 0, "months": 0, "days": 0}

--- a/hr_employee_service/tests/test_hr_employee_service.py
+++ b/hr_employee_service/tests/test_hr_employee_service.py
@@ -128,3 +128,16 @@ class TestHrEmployeeService(common.TransactionCase):
 
         self.assertEqual(employee.service_duration, 0)
         employee._get_date_start_work()
+
+    def test_get_service_duration_from_date(self):
+        employee = self.SudoEmployee.create(
+            {
+                "name": "Employee #9",
+                "service_hire_date": (self.today - relativedelta(years=1)),
+                "service_start_date": (self.today - relativedelta(years=1)),
+            }
+        )
+        search_date = self.today - relativedelta(months=10)
+        result = employee.get_service_duration_from_date(search_date)
+        self.assertEqual(result["years"], 0)
+        self.assertEqual(result["months"], 2)


### PR DESCRIPTION
This PR adds a helper function to return the employee service duration but for a given date. 
This is useful for modules like payroll, when you usually need the service years or months of a employee but calculated to the date of the payslip. 

Currently, this module fields, will return ACTUAL service years, months and days, but if for example you are calculating a March payslip in April, you will get April values, not March. 

This new simple helper function, will help users in payroll to return the values needed based on payslip dates (using `employee.get_service_duration_from_date(payslip.start_date)`) and also could be useful for another scenarios when you need to compute this values for a fixed date. 

Regards. 