### PR TITLE
[14.0][IMP] hr_employee_calendar_planning: set calendar_ids from Create employee button from user

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -151,6 +151,25 @@ class HrEmployee(models.Model):
         new.filtered("calendar_ids").regenerate_calendar()
         return new
 
+    def _sync_user(self, user, employee_has_image=False):
+        res = super()._sync_user(user=user, employee_has_image=employee_has_image)
+        # set calendar_ids from Create employee button from user
+        res.update(
+            {
+                "calendar_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "date_start": fields.Date.today(),
+                            "calendar_id": user.company_id.resource_calendar_id.id,
+                        },
+                    ),
+                ]
+            }
+        )
+        return res
+
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)


### PR DESCRIPTION
Set `calendar_ids` from "_Create employee_" button from user.

Related to: https://github.com/OCA/hr/issues/1163

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa