### PR TITLE
[15.0][IMP] hr_employee_calendar_planning: set calendar_ids from Create employee button from user

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -151,6 +151,25 @@ class HrEmployee(models.Model):
         new.filtered("calendar_ids").regenerate_calendar()
         return new
 
+    def _sync_user(self, user, employee_has_image=False):
+        res = super()._sync_user(user=user, employee_has_image=employee_has_image)
+        # set calendar_ids from Create employee button from user
+        res.update(
+            {
+                "calendar_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "date_start": fields.Date.today(),
+                            "calendar_id": user.company_id.resource_calendar_id.id,
+                        },
+                    ),
+                ]
+            }
+        )
+        return res
+
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import exceptions, fields
-from odoo.tests import common
+from odoo.tests import common, new_test_user
 
 from ..hooks import post_init_hook
 
@@ -12,6 +12,15 @@ class TestHrEmployeeCalendarPlanning(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                mail_create_nolog=True,
+                mail_create_nosubscribe=True,
+                mail_notrack=True,
+                no_reset_password=True,
+            )
+        )
         resource_calendar = cls.env["resource.calendar"]
         cls.calendar1 = resource_calendar.create(
             {"name": "Test calendar 1", "attendance_ids": []}
@@ -430,4 +439,12 @@ class TestHrEmployeeCalendarPlanning(common.TransactionCase):
         self.assertTrue(employee2.resource_calendar_id.auto_generate)
         self.assertNotEqual(
             self.employee.resource_calendar_id, employee2.resource_calendar_id
+        )
+
+    def test_user_action_create_employee(self):
+        user = new_test_user(self.env, login="test-user")
+        user.action_create_employee()
+        self.assertIn(
+            user.company_id.resource_calendar_id,
+            user.employee_id.mapped("calendar_ids.calendar_id"),
         )


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/hr/pull/1224

Set `calendar_ids` from "_Create employee_" button from user.

Related to: https://github.com/OCA/hr/issues/1163

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa