### PR TITLE
[15.0][IMP] hr_employee_calendar_planning: remove date_start from _sync_user

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -161,7 +161,6 @@ class HrEmployee(models.Model):
                         0,
                         0,
                         {
-                            "date_start": fields.Date.today(),
                             "calendar_id": user.company_id.resource_calendar_id.id,
                         },
                     ),


### PR DESCRIPTION
Setting a date_start in the _sync_user method causes some of Odoo's tests to fail as soon as hr_employee_calendar_planning is among the installed modules. This is due to the fact that the users created in tests will not have any planned attendances prior to their create date, which some tests are expecting.
Examples:
```
[odoo.addons.hr_holidays.tests.test_leave_requests:770]

ERROR: TestLeaveRequests.test_archived_allocation
Traceback (most recent call last):
  File "/data/build/odoo/addons/hr_holidays/tests/test_leave_requests.py", line 770, in test_archived_allocation
    leave_2021.with_user(self.user_hrmanager_id).action_approve()
  File "/data/build/odoo/addons/hr_holidays/models/hr_leave.py", line 1130, in action_approve
    self.filtered(lambda hol: not hol.validation_type == 'both').action_validate()
  File "/data/build/odoo/addons/hr_holidays/models/hr_leave.py", line 1142, in action_validate
    raise ValidationError(_('The following employees are not supposed to work during that period:\n %s') % ','.join(leaves.mapped('employee_id.name')))
odoo.exceptions.ValidationError: The following employees are not supposed to work during that period:
 David Employee
```
```
[odoo.addons.project_timesheet_holidays.tests.test_timesheet_holidays:106]

FAIL: TestTimesheetHolidays.test_validate_with_timesheet
Traceback (most recent call last):
  File "/data/build/odoo/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py", line 106, in test_validate_with_timesheet
    self.assertEqual(len(holiday.timesheet_ids), number_of_days, 'Number of generated timesheets should be the same as the leave duration (1 per day between %s and %s)' % (fields.Datetime.to_string(self.leave_start_datetime), fields.Datetime.to_string(self.leave_end_datetime)))
AssertionError: 0 != 3 : Number of generated timesheets should be the same as the leave duration (1 per day between 2018-02-05 07:00:00 and 2018-02-08 07:00:00)
```

Since date_start is not a required field for the calendars, I suggest leaving it empty by default, as to not interfere with the tests.