### PR TITLE
[14.0][FIX] hr_course: i18n spain translation

### DIFF
--- a/hr_course/i18n/es.po
+++ b/hr_course/i18n/es.po
@@ -292,7 +292,7 @@ msgstr "Empleado"
 #: code:addons/hr_course/models/hr_course_schedule.py:0
 #, python-format
 msgid "Employees removed from this course: <br></br>%s"
-msgstr "Empleados eliminados de este curso: <br></br>"
+msgstr "Empleados eliminados de este curso: <br></br>%s"
 
 #. module: hr_course
 #: model:ir.model.fields,field_description:hr_course.field_hr_course_attendee__course_end


### PR DESCRIPTION
Detected bad translation that it provoke an error in view.  
When I go to draft a started course to remove an attendee and I want to start it again, it returns the following error:
![image](https://github.com/OCA/hr/assets/55379877/10b57773-b89c-43b3-add5-064a2eb11585)
