### PR TITLE
[14.0][IMP] hr_employee_calendar_planning: remove date_start from _sync_user

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -161,7 +161,6 @@ class HrEmployee(models.Model):
                         0,
                         0,
                         {
-                            "date_start": fields.Date.today(),
                             "calendar_id": user.company_id.resource_calendar_id.id,
                         },
                     ),


### PR DESCRIPTION
Backport from 15.0: https://github.com/OCA/hr/pull/1230

remove `date_start` from `_sync_user()` method

Please @pedrobaeza can you review it?

@Tecnativa