### PR TITLE
[12.0][FIX] - hr_attendance_rfid - Handle ValidationError properly

### DIFF
--- a/hr_attendance_rfid/models/hr_employee.py
+++ b/hr_attendance_rfid/models/hr_employee.py
@@ -65,6 +65,6 @@ class HrEmployee(models.Model):
                 res['error_message'] = msg
                 return res
         except Exception as e:
-            res['error_message'] = e
-            _logger.error(e)
+            res['error_message'] = str(e)
+            _logger.error(str(e))
         return res


### PR DESCRIPTION
A ValidationError has to be converted to a string explicitly, otherwise an error is produced if it is used as a string.