### PR TITLE
[15.0][IMP] hr_employee_calendar_planning: Allow to archive when calendars have finished

### DIFF
--- a/hr_employee_calendar_planning/__manifest__.py
+++ b/hr_employee_calendar_planning/__manifest__.py
@@ -9,7 +9,11 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": ["hr"],
-    "data": ["security/ir.model.access.csv", "views/hr_employee_views.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/hr_employee_views.xml",
+        "views/resource_calendar_views.xml",
+    ],
     "post_init_hook": "post_init_hook",
     "maintainers": ["victoralmau", "pedrobaeza"],
 }

--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -11,12 +11,18 @@ class ResourceCalendar(models.Model):
 
     active = fields.Boolean(default=True)
     auto_generate = fields.Boolean()
+    employee_calendar_ids = fields.One2many("hr.employee.calendar", "calendar_id")
 
     @api.constrains("active")
     def _check_active(self):
         for item in self:
             total_items = self.env["hr.employee.calendar"].search_count(
-                [("calendar_id", "=", item.id)]
+                [
+                    ("calendar_id", "=", item.id),
+                    "|",
+                    ("date_end", "=", False),
+                    ("date_end", "<=", fields.Date.today()),
+                ]
             )
             if total_items:
                 raise ValidationError(

--- a/hr_employee_calendar_planning/views/resource_calendar_views.xml
+++ b/hr_employee_calendar_planning/views/resource_calendar_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Creu Blanca
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="resource_calendar_form" model="ir.ui.view">
+        <field name="model">resource.calendar</field>
+        <field name="inherit_id" ref="resource.resource_calendar_form" />
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page name="employee_calendar" string="Employee Calendars">
+                    <field name="employee_calendar_ids">
+                        <tree editable="top" create="0">
+                            <field name="company_id" invisible="1" />
+                            <field name="date_start" />
+                            <field name="date_end" />
+                            <field name="employee_id" />
+                        </tree>
+                    </field>
+                </page>
+            </notebook>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/hr/pull/1239

Otherwise, we may loose the original calendars of employees if we want to archive old calendars.

Show them on calendar view too in order to check which employees uses the calendar.

@Tecnativa
