### PR TITLE
[FIX] Fixed bug by adding hr.group_hr_user group to field not availab…

### DIFF
--- a/hr_employee_birthday_mail/models/hr_employee.py
+++ b/hr_employee_birthday_mail/models/hr_employee.py
@@ -11,11 +11,13 @@ class HrEmployee(models.Model):
 
     allow_birthday_wishes = fields.Boolean(
         default=False,
+        groups="hr.group_hr_user",
         help="Check this box if you want to allow birthday wishes from our company "
         "and allow the others to be notified of your birthday.",
     )
     notify_others_birthday = fields.Boolean(
         default=False,
+        groups="hr.group_hr_user",
         help="Check this box if you want to be notified about other coworkers' birthdays.",
     )
 


### PR DESCRIPTION
Fixed bug by adding hr.group_hr_user group to fields not available in hr.employee.public.

Basically the same problem as [!1160](https://github.com/OCA/hr/pull/1160), but for other fields in another module.
