### PR TITLE
[13.0][IMP] hr_employee_calendar_planning: Set calendar_ids default value to cover all use cases

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -48,6 +48,16 @@ class HrEmployee(models.Model):
         copy=True,
     )
 
+    @api.model
+    def default_get(self, fields):
+        """Set calendar_ids default value to cover all use cases."""
+        vals = super().default_get(fields)
+        if "calendar_ids" in fields and not vals.get("calendar_ids"):
+            vals["calendar_ids"] = [
+                (0, 0, {"calendar_id": self.env.company.resource_calendar_id.id}),
+            ]
+        return vals
+
     def _regenerate_calendar(self):
         self.ensure_one()
         vals_list = []
@@ -122,32 +132,17 @@ class HrEmployee(models.Model):
         new.filtered("calendar_ids").regenerate_calendar()
         return new
 
-    def _sync_user(self, user):
-        res = super()._sync_user(user=user)
-        # set calendar_ids from Create employee button from user
-        if not self.calendar_ids:
-            res.update(
-                {
-                    "calendar_ids": [
-                        (
-                            0,
-                            0,
-                            {"calendar_id": user.company_id.resource_calendar_id.id},
-                        ),
-                    ]
-                }
-            )
-        return res
-
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
+        # Avoid creating an employee without calendars
         if (
             not self.env.context.get("skip_employee_calendars_required")
             and not config["test_enable"]
             and res.filtered(lambda x: not x.calendar_ids)
         ):
             raise UserError(_("You can not create employees without any calendars."))
+        # Regenerate calendar
         res.filtered("calendar_ids").regenerate_calendar()
         return res
 

--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -155,7 +155,7 @@ class HrEmployeeCalendar(models.Model):
     date_start = fields.Date(string="Start Date",)
     date_end = fields.Date(string="End Date",)
     employee_id = fields.Many2one(
-        comodel_name="hr.employee", string="Employee", required=True,
+        comodel_name="hr.employee", string="Employee", required=True, ondelete="cascade"
     )
     company_id = fields.Many2one(related="employee_id.company_id")
     calendar_id = fields.Many2one(
@@ -163,6 +163,7 @@ class HrEmployeeCalendar(models.Model):
         string="Working Time",
         required=True,
         check_company=True,
+        ondelete="restrict",
     )
 
     _sql_constraints = [

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -19,6 +19,8 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
                 mail_create_nosubscribe=True,
                 mail_notrack=True,
                 no_reset_password=True,
+                tracking_disable=True,
+                test_hr_employee_calendar_planning=True,
             )
         )
         resource_calendar = cls.env["resource.calendar"]
@@ -73,6 +75,8 @@ class TestHrEmployeeCalendarPlanning(common.SavepointCase):
                 "date_to": "2019-06-10",
             }
         )
+        # By default a calendar_ids is set, we remove it to better clarify the tests.
+        cls.employee.write({"calendar_ids": [(2, cls.employee.calendar_ids.id)]})
 
     def test_calendar_planning(self):
         self.employee.calendar_ids = [


### PR DESCRIPTION
Set calendar_ids default value to cover all use cases.

Steps to reproduce the error (before):
- Go to Recruitment > Apllications and enter one of them.
- Click on the "_Create employee_" button and confirm.

An error is displayed when trying to create the employee because there is no calendar defined.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT44093