### PR TITLE
[16.0][IMP] hr_employee_age: Add groups="hr.group_hr_user" to age field according to birthday field definition

### DIFF
--- a/hr_employee_age/models/hr_employee.py
+++ b/hr_employee_age/models/hr_employee.py
@@ -8,7 +8,11 @@ from odoo import api, fields, models
 class HrEmployee(models.Model):
     _inherit = "hr.employee"
 
-    age = fields.Integer(compute="_compute_age")
+    # The age field uses a depends (birthday) that has defined
+    # groups="hr.group_hr_user", if a user without permissions in HR tries to get
+    # the value of this field will have an error.
+    # The correct way to avoid this inconsistency is to define groups to field age
+    age = fields.Integer(compute="_compute_age", groups="hr.group_hr_user")
 
     @api.depends("birthday")
     def _compute_age(self):


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/hr/pull/1268

Add `groups="hr.group_hr_user"` to age field according to `birthday` field definition `(https://github.com/odoo/odoo/blob/16.0/addons/hr/models/hr_employee.py#L71)`

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT43046