### PR TITLE
[15.0][IMP] hr_contract_employee_calendar_planning

### DIFF
--- a/hr_contract_employee_calendar_planning/hooks.py
+++ b/hr_contract_employee_calendar_planning/hooks.py
@@ -14,7 +14,7 @@ def post_init_hook(cr, registry, employees=None):
 
     for employee in employees.filtered("contract_ids"):
         contract_calendar_lines = []
-        for contract in employee.contract_ids:
+        for contract in employee.contract_ids.sorted("date_start"):
             date_start = contract.date_start
             date_end = contract.date_end
             # filter calendar_ids to check for overlaps with contracts
@@ -26,7 +26,7 @@ def post_init_hook(cr, registry, employees=None):
             )
             if cal_ids:
                 _logger.info(f"{contract} is overlapping with {cal_ids}")
-                for calendar in cal_ids:
+                for calendar in cal_ids.sorted("date_start"):
                     if date_start and calendar.date_start != date_start:
                         _logger.info(
                             f"changing date_start of {calendar} "
@@ -39,6 +39,7 @@ def post_init_hook(cr, registry, employees=None):
                             f"from {calendar.date_end} to {date_end}"
                         )
                         calendar.date_end = date_end
+                    break
             else:
                 _logger.info(
                     f"adding new calendar_id for {contract.employee_id.name}: "

--- a/hr_contract_employee_calendar_planning/tests/test_hr_contract_employee_calendar_planning.py
+++ b/hr_contract_employee_calendar_planning/tests/test_hr_contract_employee_calendar_planning.py
@@ -6,56 +6,47 @@ from ..hooks import post_init_hook
 
 
 class TestHrContractEmployeeCalendarPlanning(TestContractCommon):
-    def setUp(self):
-        super().setUp()
-        calendar_ids = [
-            (
-                0,
-                0,
-                {
-                    "date_start": False,
-                    "date_end": datetime.strptime("2020-11-30", "%Y-%m-%d").date(),
-                    "calendar_id": self.env["resource.calendar"].browse([2]).id,
-                },
-            ),
-            (
-                0,
-                0,
-                {
-                    "date_start": datetime.strptime("2020-12-01", "%Y-%m-%d").date(),
-                    "date_end": False,
-                    "calendar_id": self.env["resource.calendar"].browse([1]).id,
-                },
-            ),
-        ]
-        self.employee.calendar_ids = calendar_ids
-
     def test_calendar_migration_from_contracts(self):
-        self.contract1 = self.env["hr.contract"].create(
+        # newly created contracts get the same calendar as the employee
+        self.employee.resource_calendar_id = self.env["resource.calendar"].browse([1])
+        self.env["hr.contract"].create(
             {
                 "name": "contract1",
-                "employee_id": self.employee.id,
                 "wage": 1,
                 "state": "close",
-                "kanban_state": "normal",
-                "resource_calendar_id": self.env["resource.calendar"].browse([1]).id,
+                "employee_id": self.employee.id,
                 "date_start": datetime.strptime("2018-11-30", "%Y-%m-%d").date(),
                 "date_end": datetime.strptime("2019-11-30", "%Y-%m-%d").date(),
             }
         )
-        self.contract2 = self.env["hr.contract"].create(
+        self.employee.resource_calendar_id = self.env["resource.calendar"].browse([2])
+        self.env["hr.contract"].create(
             {
                 "name": "contract2",
-                "employee_id": self.employee.id,
                 "wage": 1,
                 "state": "open",
-                "kanban_state": "normal",
-                "resource_calendar_id": self.env["resource.calendar"].browse([2]).id,
+                "employee_id": self.employee.id,
                 "date_start": datetime.strptime("2019-12-01", "%Y-%m-%d").date(),
                 "date_end": datetime.strptime("2020-11-30", "%Y-%m-%d").date(),
             }
         )
-        original_cal_ids = self.employee.calendar_ids.ids
+        calendar_ids = self.env["hr.employee.calendar"].create(
+            [
+                {
+                    "date_start": False,
+                    "date_end": datetime.strptime("2020-11-30", "%Y-%m-%d").date(),
+                    "calendar_id": 2,
+                    "employee_id": self.employee.id,
+                },
+                {
+                    "date_start": datetime.strptime("2020-12-01", "%Y-%m-%d").date(),
+                    "date_end": False,
+                    "calendar_id": 1,
+                    "employee_id": self.employee.id,
+                },
+            ]
+        )
+        self.employee.calendar_ids = [(6, 0, calendar_ids.ids)]
         start_dt = datetime(2019, 1, 1, 0, 0, 0)
         end_dt = datetime(2019, 1, 2, 0, 0, 0)
         self.assertEqual(
@@ -74,6 +65,4 @@ class TestHrContractEmployeeCalendarPlanning(TestContractCommon):
                 end_dt=end_dt,
             ),
         )
-        self.assertTrue(
-            all(ids in self.employee.calendar_ids.ids for ids in original_cal_ids)
-        )
+        self.assertTrue(calendar_ids.ids < self.employee.calendar_ids.ids)

--- a/hr_contract_employee_calendar_planning/views/contract.xml
+++ b/hr_contract_employee_calendar_planning/views/contract.xml
@@ -11,4 +11,19 @@
             </xpath>
         </field>
     </record>
+
+    <record model="ir.ui.view" id="hr_contract_employee_calendar_history_form">
+        <field name="name">hr.contract.employee.calendar.planning.history.form</field>
+        <field name="model">hr.contract.history</field>
+        <field name="inherit_id" ref="hr_contract.hr_contract_history_view_form" />
+        <field name="priority">999</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='resource_calendar_id']" position="replace">
+                <field name="resource_calendar_id" invisible="1" />
+            </xpath>
+            <xpath expr="//tree/field[@name='resource_calendar_id']" position="replace">
+                <field name="resource_calendar_id" invisible="1" />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Improve hr_contract_employee_calendar_planning:
- hide resource_calendar_id in hr_contract_history view
- make sure that creating new contracts does not overwrite the auto-generated calendar
- the post-install hook should only crop the first calendar if there are multiple overlaps