### PR TITLE
[14.0][FIX] hr_employee_firstname and hr_employee_lastnames

### DIFF
--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -91,8 +91,10 @@ class HrEmployee(models.Model):
                 firstname = self.firstname
             vals["name"] = self._get_name(lastname, firstname)
         elif vals.get("name"):
-            vals["lastname"] = self.split_name(vals["name"])["lastname"]
-            vals["firstname"] = self.split_name(vals["name"])["firstname"]
+            for rec in self:
+                if not rec.name or rec.name != vals.get("name"):
+                    vals["lastname"] = self.split_name(vals["name"])["lastname"]
+                    vals["firstname"] = self.split_name(vals["name"])["firstname"]
 
     @api.model
     def _get_whitespace_cleaned_name(self, name, comma=False):

--- a/hr_employee_firstname/tests/test_hr_employee_firstname.py
+++ b/hr_employee_firstname/tests/test_hr_employee_firstname.py
@@ -171,3 +171,11 @@ class TestEmployeeFirstname(TransactionCase):
 
         self.assertEqual(self.employee1_id.firstname, "Jean-Pierre")
         self.assertEqual(self.employee1_id.lastname, "Carnaud-Eyck")
+
+    def test_change_name_with_the_same_name(self):
+        self.employee1_id.write(
+            {"firstname": "Maxime Françis", "lastname": "Patrick Dubois"}
+        )
+        self.employee1_id.write({"name": "Maxime Françis Patrick Dubois"})
+        self.assertEqual(self.employee1_id.firstname, "Maxime Françis")
+        self.assertEqual(self.employee1_id.lastname, "Patrick Dubois")

--- a/hr_employee_lastnames/models/hr_employee.py
+++ b/hr_employee_lastnames/models/hr_employee.py
@@ -66,10 +66,12 @@ class HrEmployee(models.Model):
                 lastname2 = self.lastname2
             vals["name"] = self._get_name_lastnames(lastname, firstname, lastname2)
         elif vals.get("name"):
-            name_splitted = self.split_name(vals["name"])
-            vals["lastname"] = name_splitted["lastname"]
-            vals["firstname"] = name_splitted["firstname"]
-            vals["lastname2"] = name_splitted["lastname2"]
+            for rec in self:
+                if rec.name != vals.get("name"):
+                    name_splitted = self.split_name(vals["name"])
+                    vals["lastname"] = name_splitted["lastname"]
+                    vals["firstname"] = name_splitted["firstname"]
+                    vals["lastname2"] = name_splitted["lastname2"]
         return res
 
     def _update_partner_firstname(self):

--- a/hr_employee_lastnames/tests/test_hr_employee_lastnames.py
+++ b/hr_employee_lastnames/tests/test_hr_employee_lastnames.py
@@ -161,3 +161,16 @@ class TestEmployeeLastnames(TransactionCase):
         self.employee1_id.refresh()
 
         self.assertEqual(self.employee1_id.name, "Lopez Gonzalez, Manuel")
+
+    def test_change_name_with_the_same_name(self):
+        self.employee1_id.write(
+            {
+                "firstname": "Maxime Françis Patrick",
+                "lastname": "Dubois",
+                "lastname2": "",
+            }
+        )
+        self.employee1_id.write({"name": "Maxime Françis Patrick Dubois"})
+        self.assertEqual(self.employee1_id.firstname, "Maxime Françis Patrick")
+        self.assertEqual(self.employee1_id.lastname, "Dubois")
+        self.assertEqual(self.employee1_id.lastname2, "")


### PR DESCRIPTION
This PR fixes an unexpected behavior when importing a file updating employees.
If we import the column employee name while keeping the same name, the method  _prepare_vals_on_write_firstname_lastname split again the name into firstname, lastname and lastname2. But the result may be different from what is present in db

I added a unit test that failed if we don't use the correction for both modules


