### PR TITLE
[12.0][FIX] hr_employee_calendar_planning: Allow duplicate employee and not copy resource calendar

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -47,6 +47,15 @@ class HrEmployee(models.Model):
             record.regenerate_calendar()
         return record
 
+    @api.multi
+    def copy_data(self, default=None):
+        if default is None:
+            default = {}
+        res = super(HrEmployee, self).copy_data(default)
+        for element in res:
+            if element.get('resource_calendar_id', False):
+                element['resource_calendar_id'] = self.env['res.company']._company_default_get().resource_calendar_id.id
+        return res
 
 class HrEmployeeCalendar(models.Model):
     _name = 'hr.employee.calendar'


### PR DESCRIPTION
When an employee is duplicated, resource calendar is not copied to new employee, so the calendar resource set in new employee is not auto-generated.

Before, resource calendar is copied to new employee and system don't generate resource calendar auto-generated.

@fcvalgar please review.

MT-3954