### PR TITLE
[16.0][IMP] hr_employee_relative: Compute children

### DIFF
--- a/hr_employee_relative/models/hr_employee.py
+++ b/hr_employee_relative/models/hr_employee.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class HrEmployee(models.Model):
@@ -11,3 +11,20 @@ class HrEmployee(models.Model):
         comodel_name="hr.employee.relative",
         inverse_name="employee_id",
     )
+
+    children = fields.Integer(
+        compute="_compute_children",
+        store=True,
+        readonly=True,
+    )
+
+    @api.depends("relative_ids.relation_id")
+    def _compute_children(self):
+        child_relation_id = self.env.ref("hr_employee_relative.relation_child").id
+
+        for employee in self:
+            employee.children = len(
+                employee.relative_ids.filtered(
+                    lambda r: r.relation_id.id == child_relation_id
+                )
+            )

--- a/hr_employee_relative/views/hr_employee.xml
+++ b/hr_employee_relative/views/hr_employee.xml
@@ -15,9 +15,6 @@
             <field name="spouse_birthdate" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
-            <field name="children" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
             <xpath expr="//notebook" position="inside">
                 <page string="Relatives" groups="hr.group_hr_user">
                     <field name="relative_ids" nolabel="1" />


### PR DESCRIPTION
In the employee form, make the children number field become a function field, its value being computed from the relatives field added by this module, where the relatives are explicitly declared as children.