### PR TITLE
[16.0][IMP] hr_employee_relative: Compute children

### DIFF
--- a/hr_employee_relative/models/hr_employee.py
+++ b/hr_employee_relative/models/hr_employee.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class HrEmployee(models.Model):
@@ -11,3 +11,20 @@ class HrEmployee(models.Model):
         comodel_name="hr.employee.relative",
         inverse_name="employee_id",
     )
+
+    children = fields.Integer(
+        compute="_compute_children",
+        store=True,
+        readonly=True,
+    )
+
+    @api.depends("relative_ids.relation_id")
+    def _compute_children(self):
+        child_relation_id = self.env.ref("hr_employee_relative.relation_child").id
+
+        for employee in self:
+            employee.children = len(
+                employee.relative_ids.filtered(
+                    lambda r: r.relation_id.id == child_relation_id
+                )
+            )

--- a/hr_employee_relative/tests/test_hr_employee_relatives.py
+++ b/hr_employee_relative/tests/test_hr_employee_relatives.py
@@ -13,6 +13,10 @@ class TestHrEmployeeRelatives(common.TransactionCase):
         super().setUp()
         self.Employee = self.env["hr.employee"]
         self.EmployeeRelative = self.env["hr.employee.relative"]
+        self.relation_child = self.env.ref("hr_employee_relative.relation_child")
+        self.relation_grandchild = self.env.ref(
+            "hr_employee_relative.relation_grandchild"
+        )
         self.relation_sibling = self.env.ref("hr_employee_relative.relation_sibling")
 
     def test_age_calculation(self):
@@ -41,3 +45,62 @@ class TestHrEmployeeRelatives(common.TransactionCase):
             f.partner_id = self.env.ref("base.res_partner_2")
             f.relation_id = self.relation_sibling
         self.assertEqual(relative.name, relative.partner_id.display_name)
+
+    def test_children_calculation(self):
+        employee = self.Employee.create(
+            {
+                "name": "Employee 2",
+                "relative_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "relation_id": self.relation_sibling.id,
+                            "name": "Relative 1",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "relation_id": self.relation_child.id,
+                            "name": "Relative 2",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "relation_id": self.relation_grandchild.id,
+                            "name": "Relative 3",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "relation_id": self.relation_child.id,
+                            "name": "Relative 4",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "relation_id": self.relation_child.id,
+                            "name": "Relative 5",
+                        },
+                    ),
+                ],
+            }
+        )
+
+        grandchild = self.EmployeeRelative.browse(employee.relative_ids[2].id)
+        child = self.EmployeeRelative.browse(employee.relative_ids[4].id)
+        self.assertEqual(employee.children, 3)
+
+        child.unlink()
+        self.assertEqual(employee.children, 2)
+
+        grandchild.relation_id = self.relation_child.id
+        self.assertEqual(employee.children, 3)

--- a/hr_employee_relative/views/hr_employee.xml
+++ b/hr_employee_relative/views/hr_employee.xml
@@ -15,9 +15,6 @@
             <field name="spouse_birthdate" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
-            <field name="children" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
             <xpath expr="//notebook" position="inside">
                 <page string="Relatives" groups="hr.group_hr_user">
                     <field name="relative_ids" nolabel="1" />


### PR DESCRIPTION
In the employee form, make the children number field become a function field, its value being computed from the relatives field added by this module, where the relatives are explicitly declared as children.