### PR TITLE
[FIX] hr_employee_document: ir.rule _compute_domain method

### DIFF
--- a/hr_employee_document/models/ir_rule.py
+++ b/hr_employee_document/models/ir_rule.py
@@ -33,3 +33,4 @@ class IrRule(models.Model):
         ):
             extra_domain = [[("id", "in", user.employee_ids.ids)]]
             res = expression.AND(extra_domain + [res])
+        return res


### PR DESCRIPTION
In the backport of PR 1271, there apparently was an error, and the return res from the _compute_domain method was missing.

#1271 
https://github.com/OCA/hr/pull/1271/files#diff-cae07833014f4bd43c276dd663343b54a78b89efe082ded465c795f4c9595ab8R36

#1320 
https://github.com/OCA/hr/pull/1320/commits/1183f7426e97305649141defbb471fa3f7995057#diff-cae07833014f4bd43c276dd663343b54a78b89efe082ded465c795f4c9595ab8R35

cc @kaynnan @douglascstd 