### PR TITLE
[13.0][FIX] hr_employee_ppe: fix migration script

### DIFF
--- a/hr_employee_ppe/migrations/13.0.2.0.0/post-migration.py
+++ b/hr_employee_ppe/migrations/13.0.2.0.0/post-migration.py
@@ -61,7 +61,7 @@ def migrate(env, version):
             'valid',
             ppe_equipment.product_id,
             hr_ppe.start_date,
-            hr_ppe.expiry_date,
+            hr_ppe.end_date,
             hr_ppe.indications,
             hr_ppe.expire,
             hr_ppe.certification,


### PR DESCRIPTION
OpenUpgrade claims that the hr_employee_ppe model does not have a field called expiry_date and that we should use the end_date field

cc: @kaynnan