### PR TITLE
[16.0][FIX]hr_employee_calendar_planning:create multi calendars

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -222,9 +222,10 @@ class HrEmployeeCalendar(models.Model):
 
     @api.model_create_multi
     def create(self, vals):
-        record = super(HrEmployeeCalendar, self).create(vals)
-        record.employee_id._regenerate_calendar()
-        return record
+        res = super(HrEmployeeCalendar, self).create(vals)
+        for employee in res.mapped("employee_id"):
+            employee._regenerate_calendar()
+        return res
 
     def write(self, vals):
         res = super(HrEmployeeCalendar, self).write(vals)

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -445,3 +445,12 @@ class TestHrEmployeeCalendarPlanning(common.TransactionCase):
             user.company_id.resource_calendar_id,
             user.employee_id.mapped("calendar_ids.calendar_id"),
         )
+
+    def test_create_employee_multi(self):
+        employees = self.env["hr.employee"].create(
+            [
+                {"name": "multi employee 1"},
+                {"name": "multi employee 2"},
+            ]
+        )
+        self.assertEqual(len(employees), 2)


### PR DESCRIPTION
Changed the create method of the model hr.employee.calendar to work the same as the write and unlink methods.
Reason: when creating multiple records of this model at the same time the method  _regenerate_calendar() will be called with multiple records. So the ensure_one() will throw an error.
The same happens when trying to create multiple employees. 