### PR TITLE
[FIX] hr_employee_ppe: fix error when assigning multiple PPE to an employee.

### DIFF
--- a/hr_employee_ppe/models/hr_employee_ppe.py
+++ b/hr_employee_ppe/models/hr_employee_ppe.py
@@ -75,7 +75,7 @@ class HrEmployeePPE(models.Model):
     @api.constrains("start_date", "end_date")
     def _check_dates(self):
         for record in self:
-            if self.expire:
+            if record.expire:
                 if not record.end_date or not record.start_date:
                     raise ValidationError(
                         _(

--- a/hr_employee_ppe/tests/test_hr_employee_ppe.py
+++ b/hr_employee_ppe/tests/test_hr_employee_ppe.py
@@ -36,3 +36,22 @@ class TestHREmployeePPE(SavepointCase):
         self.assertEqual(self.hr_employee_ppe1.name,
                          "Mask for COVID-19 to Abigail Peterson")
         self.assertEqual(self.hr_employee_ppe1.expire, True)
+
+    def test_hr_employee_ppe_multi(self):
+        employee = self.env.ref('hr.employee_hne')
+        today = datetime.now().strftime('%Y-%m-%d')
+        tomorrow = (datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d')
+        employee.write({
+            'ppe_ids': [
+                (0, 0, {
+                    'ppe_id': self.hr_employee_ppe1.id,
+                    'start_date': today,
+                    'end_date': tomorrow,
+                }),
+                (0, 0, {
+                    'ppe_id': self.hr_employee_ppe2.id,
+                    'start_date': today,
+                    'end_date': tomorrow,
+                }),
+            ],
+        })


### PR DESCRIPTION
Fix
'''
     Error while validating constraint
     Expected singleton: hr.employee.ppe(5, 6)
'''
error when assigning multiple PPE to an employee.