### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/hr_employee_birth_name/__manifest__.py
+++ b/hr_employee_birth_name/__manifest__.py
@@ -7,7 +7,7 @@
     "name": "Employee Birth Name",
     "version": "14.0.1.0.1",
     "category": "Human Resources",
-    "author": "Camptocamp SA,Odoo Community Association (OCA),"
+    "author": "Camptocamp,Odoo Community Association (OCA),"
     "Open Source Integrators",
     "website": "https://github.com/OCA/hr",
     "license": "AGPL-3",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.