### PR TITLE
[11.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/hr_employee_birth_name/__manifest__.py
+++ b/hr_employee_birth_name/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Employee Birth Name',
     'version': '11.0.1.0.0',
     'category': 'Human Resources',
-    'author': "Camptocamp SA,Odoo Community Association (OCA)",
+    'author': "Camptocamp,Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/hr',
     'license': 'AGPL-3',
     'depends': ['hr', ],

--- a/hr_employee_seniority/__manifest__.py
+++ b/hr_employee_seniority/__manifest__.py
@@ -9,7 +9,7 @@
     'version': '11.0.1.0.0',
     'category': 'Human Resources',
     'author': "Michael Telahun Makonnen <mmakonnen@gmail.com>, "
-              "Camptocamp SA, "
+              "Camptocamp, "
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/hr',
     'license': 'AGPL-3',

--- a/hr_employee_social_media/__manifest__.py
+++ b/hr_employee_social_media/__manifest__.py
@@ -9,7 +9,7 @@
     'category': 'Human Resources',
     'author':
         'CorporateHub, '
-        'Camptocamp SA, '
+        'Camptocamp, '
         'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/hr',
     'license': 'AGPL-3',

--- a/hr_holidays_imposed_days/__manifest__.py
+++ b/hr_holidays_imposed_days/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '11.0.1.0.0',
     'category': 'Human Resources',
     'license': 'AGPL-3',
-    'author': 'Camptocamp SA, '
+    'author': 'Camptocamp, '
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/hr',
     'depends': ['hr_holidays'],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 11.0.