### PR TITLE
[10.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/hr_employee_birth_name/__manifest__.py
+++ b/hr_employee_birth_name/__manifest__.py
@@ -6,7 +6,7 @@
     'name': 'Employee Birth Name',
     'version': '10.0.1.0.0',
     'category': 'Human Resources',
-    'author': "Camptocamp SA,Odoo Community Association (OCA)",
+    'author': "Camptocamp,Odoo Community Association (OCA)",
     'website': 'http://www.camptocamp.com',
     'license': 'AGPL-3',
     'depends': ['hr', ],

--- a/hr_employee_seniority/__manifest__.py
+++ b/hr_employee_seniority/__manifest__.py
@@ -10,7 +10,7 @@
     'version': '10.0.1.0.2',
     'category': 'Human Resources',
     'author': "Michael Telahun Makonnen <mmakonnen@gmail.com>, "
-              "Camptocamp SA, "
+              "Camptocamp, "
               "Odoo Community Association (OCA)",
     'website': 'http://miketelahun.wordpress.com',
     'license': 'AGPL-3',

--- a/hr_employee_social_media/__manifest__.py
+++ b/hr_employee_social_media/__manifest__.py
@@ -6,7 +6,7 @@
     'name': 'Employee Social Media',
     'version': '10.0.1.0.0',
     'category': 'Human Resources',
-    'author': "Camptocamp SA, Odoo Community Association (OCA)",
+    'author': "Camptocamp, Odoo Community Association (OCA)",
     'website': 'http://www.camptocamp.com',
     'license': 'AGPL-3',
     'depends': ['hr', ],

--- a/hr_holidays_imposed_days/__manifest__.py
+++ b/hr_holidays_imposed_days/__manifest__.py
@@ -7,7 +7,7 @@
     'version': '10.0.1.0.1',
     'category': 'Human Resources',
     'license': 'AGPL-3',
-    'author': 'Camptocamp SA, '
+    'author': 'Camptocamp, '
               'Odoo Community Association (OCA)',
     'website': 'http://www.camptocamp.com',
     'depends': ['hr_holidays'],

--- a/hr_recruitment_candidate_multi_applicant/__manifest__.py
+++ b/hr_recruitment_candidate_multi_applicant/__manifest__.py
@@ -5,7 +5,7 @@
  'summary': 'Applications',
  'version': '10.0.1.0.0',
  'category': 'Human Resources',
- 'author': 'Camptocamp SA,Odoo Community Association (OCA)',
+ 'author': 'Camptocamp,Odoo Community Association (OCA)',
  'license': 'AGPL-3',
  'depends': ['hr_recruitment'],
  'website': 'https://odoo-community.org/',

--- a/hr_recruitment_skill/__manifest__.py
+++ b/hr_recruitment_skill/__manifest__.py
@@ -7,7 +7,7 @@
     'summary': 'Add skills on job position',
     'version': '10.0.1.0.0',
     'category': 'HR',
-    'author': 'Camptocamp SA,Odoo Community Association (OCA)',
+    'author': 'Camptocamp,Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'depends': ['hr_skill',
                 'hr_recruitment',


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 10.0.