### PR TITLE
[17.0][FIX] hr_employee_firstname: removed useless mapped address_home_id

### DIFF
--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -9,7 +9,7 @@ from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
-UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "address_home_id"]
+UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "private_street"]
 
 
 class HrEmployee(models.Model):
@@ -168,7 +168,7 @@ class HrEmployee(models.Model):
     def _update_partner_firstname(self):
         for employee in self:
             partners = employee.mapped("user_id.partner_id")
-            partners |= employee.mapped("address_home_id")
+            partners |= employee.mapped("work_contact_id")
             partners.write(
                 {"firstname": employee.firstname, "lastname": employee.lastname}
             )


### PR DESCRIPTION
Remove useless mapped.
The source code has changed in OCB/OdooSA.
The relational field no longer exists on the address in V17.
https://github.com/OCA/OCB/blob/3afef8250c829406a8fd227a6bd9f71c4f80ff29/addons/hr/models/hr_employee.py#L49