### PR TITLE
[17.0][FIX] hr_employee_second_lastname: removed useless mapped address_home_id

### DIFF
--- a/hr_employee_second_lastname/models/hr_employee.py
+++ b/hr_employee_second_lastname/models/hr_employee.py
@@ -75,7 +75,7 @@ class HrEmployee(models.Model):
     def _update_partner_firstname(self):
         for employee in self:
             partners = employee.mapped("user_id.partner_id")
-            partners |= employee.mapped("address_home_id")
+            partners |= employee.mapped("work_contact_id")
             partners.write(
                 {
                     "firstname": employee.firstname,


### PR DESCRIPTION
Remove useless mapped.
The source code has changed in OCB/OdooSA.
The relational field no longer exists on the address in V17.
https://github.com/OCA/OCB/blob/3afef8250c829406a8fd227a6bd9f71c4f80ff29/addons/hr/models/hr_employee.py#L49