### PR TITLE
[FIX] hr_employee_firstname: fix DeprecationWarning

### DIFF
--- a/hr_employee_firstname/README.rst
+++ b/hr_employee_firstname/README.rst
@@ -65,13 +65,13 @@ Authors
 Contributors
 ------------
 
--  El Hadji Dem <elhadji.dem@savoirfairelinux.com>
--  Sandy Carter <sandy.carter@savoirfairelinux.com>
--  Fekete Mihai <feketemihai@gmail.com>
--  David Dufresne <david.dufresne@savoirfairelinux.com>
--  Adrien Peiffer (ACSONE) <adrien.peiffer@acsone.eu>
--  Antonio Esposito (ONESTEIN BV) <a.esposito@onestein.nl>
--  Andrea Stirpe <a.stirpe@onestein.nl>
+- El Hadji Dem <elhadji.dem@savoirfairelinux.com>
+- Sandy Carter <sandy.carter@savoirfairelinux.com>
+- Fekete Mihai <feketemihai@gmail.com>
+- David Dufresne <david.dufresne@savoirfairelinux.com>
+- Adrien Peiffer (ACSONE) <adrien.peiffer@acsone.eu>
+- Antonio Esposito (ONESTEIN BV) <a.esposito@onestein.nl>
+- Andrea Stirpe <a.stirpe@onestein.nl>
 
 Maintainers
 -----------

--- a/hr_employee_firstname/static/description/index.html
+++ b/hr_employee_firstname/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -423,7 +423,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Run the README generator to fix the warning message in the log:

`DeprecationWarning: XML declarations in HTML module descriptions are deprecated since Odoo 17, hr_employee_firstname can just have a UTF8 description with not need for a declaration.`