### PR TITLE
[FIX] hr_employee_firstname: apply same order (lastname, then firstname)

### DIFF
--- a/hr_employee_firstname/views/hr_view.xml
+++ b/hr_employee_firstname/views/hr_view.xml
@@ -12,12 +12,12 @@
             <xpath expr="//h1//field[@name='name']/.." position="after">
                 <group>
                     <field
-                        name="firstname"
-                        attrs="{'required': [('lastname', '=', False)]}"
-                    />
-                    <field
                         name="lastname"
                         attrs="{'required': [('firstname', '=', False)]}"
+                    />
+                    <field
+                        name="firstname"
+                        attrs="{'required': [('lastname', '=', False)]}"
                     />
                 </group>
             </xpath>


### PR DESCRIPTION
Trivial PR.

rational : 
for the time being, in partner form view and user form view, the fields are displayed with the following order. lastname, then firstname.

However, in the employee form view, the order is reversed.

this PR fixes this inconsistency.

Ref : 

- user view : https://github.com/OCA/partner-contact/blob/16.0/partner_firstname/views/res_user.xml#L13-L20
- partner view : https://github.com/OCA/partner-contact/blob/16.0/partner_firstname/views/res_partner.xml#L18-L29
