### PR TITLE
[16.0][FIX] hr_employee_calendar_planning: Hide resource_calendar_id even if hr_contract is installed

### DIFF
--- a/hr_employee_calendar_planning/views/hr_employee_views.xml
+++ b/hr_employee_calendar_planning/views/hr_employee_views.xml
@@ -5,6 +5,9 @@
     <record id="view_employee_form" model="ir.ui.view">
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form" />
+        <!-- It is necessary to set a high priority to avoid that if hr_contract
+        is installed later, the calendar is still hidden. !-->
+        <field name="priority">99</field>
         <field name="arch" type="xml">
             <field name="resource_calendar_id" position="attributes">
                 <attribute name="invisible">1</attribute>


### PR DESCRIPTION
Hide `resource_calendar_id` even if `hr_contract` is installed

Install `hr_employee_calendar_planning` + `hr_contract`.

**Before**
![antes](https://github.com/user-attachments/assets/602378f3-1764-4e1d-94db-8ca24b208bee)

**After**
![despues](https://github.com/user-attachments/assets/f7425f68-210e-494b-a1c6-a6783090eef3)

Please @pedrobaeza can you review it?

@Tecnativa TT54640