### PR TITLE
[FIX]hr_employee_calendar_planning:incorrect hours_per_day

### DIFF
--- a/hr_employee_calendar_planning/__manifest__.py
+++ b/hr_employee_calendar_planning/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Employee Calendar Planning",
-    "version": "16.0.1.1.9",
+    "version": "16.0.1.1.10",
     "category": "Human Resources",
     "website": "https://github.com/OCA/hr",
     "author": "Tecnativa,Odoo Community Association (OCA)",
@@ -11,6 +11,7 @@
     "depends": ["hr"],
     "data": [
         "security/ir.model.access.csv",
+        "data/data.xml",
         "views/hr_employee_views.xml",
         "views/resource_calendar_views.xml",
     ],

--- a/hr_employee_calendar_planning/data/data.xml
+++ b/hr_employee_calendar_planning/data/data.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+    <record id="ir_cron_create_time_reports" model="ir.cron">
+        <field name="name">Hr Employee: Recompute hours per day</field>
+        <field name="model_id" ref="hr_employee_calendar_planning.model_hr_employee" />
+        <field name="state">code</field>
+        <field name="code">model.cron_recompute_hours_per_day()</field>
+        <field name="interval_type">days</field>
+        <field name="interval_number">1</field>
+        <field name="numbercall">-1</field>
+        <field
+            name="nextcall"
+            eval="datetime.now().replace(hour=1, minute=0, second=0, microsecond=0) + timedelta(days=1)"
+        />
+        <field name="doall" eval="True" />
+        <field name="active" eval="True" />
+    </record>
+</odoo>

--- a/hr_employee_calendar_planning/migrations/16.0.1.1.10/post-migration.py
+++ b/hr_employee_calendar_planning/migrations/16.0.1.1.10/post-migration.py
@@ -1,0 +1,6 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["hr.employee"].cron_recompute_hours_per_day()

--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -2,6 +2,8 @@
 # Copyright 2022-2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import date
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import config
@@ -57,6 +59,43 @@ class HrEmployee(models.Model):
                 (0, 0, {"calendar_id": self.env.company.resource_calendar_id.id}),
             ]
         return vals
+
+    def _get_current_hours_per_day(self):
+        """
+        Checks all calendars and uses the most specific first (date_start and date_end are set).
+        If no calendar matches it checks for calendars where no date_end is set.
+        If no calendar matches it checks for calendars where no date_start is set.
+        If no calendar matches it checks for calenders with neither date_start nor date_end.
+        It returns the hours_per_day of the first matching resource calendar.
+        If no calendar matches or no calendar exists -1 is returned.
+        :return: the current valid hours per day
+        """
+        if not self.calendar_ids:
+            return -1
+        today = date.today()
+        relevant_calendars = self.calendar_ids.filtered(
+            lambda x: x.date_start
+            and x.date_end
+            and x.date_start <= today <= x.date_end
+        )
+        if relevant_calendars:
+            return relevant_calendars[0].calendar_id.hours_per_day
+        relevant_calendars = self.calendar_ids.filtered(
+            lambda x: x.date_start and not x.date_end and x.date_start <= today
+        )
+        if relevant_calendars:
+            return relevant_calendars[0].calendar_id.hours_per_day
+        relevant_calendars = self.calendar_ids.filtered(
+            lambda x: not x.date_start and x.date_end and today <= x.date_end
+        )
+        if relevant_calendars:
+            return relevant_calendars[0].calendar_id.hours_per_day
+        relevant_calendars = self.calendar_ids.filtered(
+            lambda x: not x.date_start and not x.date_end
+        )
+        if relevant_calendars:
+            return relevant_calendars[0].calendar_id.hours_per_day
+        return -1
 
     def _regenerate_calendar(self):
         self.ensure_one()
@@ -115,11 +154,11 @@ class HrEmployee(models.Model):
             )
         else:
             self.resource_calendar_id.attendance_ids = vals_list
-        # Set the hours per day to the last (top date end) calendar line to apply
+        # Set the hours per day to the value of the current resource calendar
+        current_hours_per_day = self._get_current_hours_per_day()
+        if current_hours_per_day >= 0:
+            self.resource_id.calendar_id.hours_per_day = current_hours_per_day
         if self.calendar_ids:
-            self.resource_id.calendar_id.hours_per_day = self.calendar_ids[
-                0
-            ].calendar_id.hours_per_day
             # set global leaves
             self.copy_global_leaves()
 
@@ -161,6 +200,13 @@ class HrEmployee(models.Model):
         )
         to_unlink.unlink()
         return self.env["resource.calendar.leaves"].create(new_vals).ids
+
+    def cron_recompute_hours_per_day(self):
+        employees = self.search([])
+        for employee in employees:
+            current_hours_per_day = employee._get_current_hours_per_day()
+            if current_hours_per_day >= 0:
+                employee.resource_id.calendar_id.hours_per_day = current_hours_per_day
 
     def regenerate_calendar(self):
         for item in self:


### PR DESCRIPTION
Always using the topmost hr.employee.calendar for hours_per_day may lead to unexpected and incorrect behavior. For example if the date_start and date_end of the topmost calendar are in the future. Then the hours_per_day from the future calendar are taken not from the currently used one. The more specific calendars in regard of date_start and date_end are considered earlier than the less specific ones.
Additionally, added a scheduled action to keep hours_per_day up to date.

How to recreate the problem:
1. Go to Employee and add a hr.employee.calendar
2. Set the date_start for yesterday and end_date for tomorrow
3. Select any resource.calendar
4. Add another hr.employee.calendar
5. Set date_start to the day after tomorrow
6. Select any other resource.calendar
7. Go to the auto generated calendar of that employee
The hours_per_day are set to the value of the topmost resource.calendar. That calendar should not be used currently. This can lead to incorrect behavior. For example for incorrect calculations of time offs.