### PR TITLE
[16.0][FIX] hr_employee_calendar_planning: Avoid error in post_init_hook with leaves that do not already exist

### DIFF
--- a/hr_employee_calendar_planning/hooks.py
+++ b/hr_employee_calendar_planning/hooks.py
@@ -61,11 +61,11 @@ def post_init_hook(cr, registry, employees=None):
             )
         # Extract employee's existing leaves so they are passed to the new
         # automatic calendar.
-        leaves = employee.resource_calendar_id.leave_ids.filtered(
-            lambda x: x.resource_id == employee.resource_id
-        )
         employee.calendar_ids = calendar_lines
         employee.resource_calendar_id.active = False
         # Now the automatic calendar has been created, so we link the
         # leaves to that one so they count correctly.
+        leaves = employee.resource_calendar_id.leave_ids.filtered(
+            lambda x: x.resource_id == employee.resource_id
+        )
         leaves.write({"calendar_id": employee.resource_calendar_id.id})


### PR DESCRIPTION
Avoid error in post_init_hook with leaves that do not already exist

Example use case:
- Install `hr_holidays`
- Install `hr_employee_calendar_planning`

```
odoo.exceptions.CacheMiss: 'resource.calendar.leaves(44,).resource_id'

odoo.exceptions.MissingError: Record does not exist or has been deleted.
(Record: resource.calendar.leaves(44,), User: 1)
```

@Tecnativa