### PR TITLE
[16.0][IMP] hr_course: inherit activity mixing model

### DIFF
--- a/hr_course/models/hr_course_schedule.py
+++ b/hr_course/models/hr_course_schedule.py
@@ -7,7 +7,7 @@ from odoo.exceptions import ValidationError
 class HrCourseSchedule(models.Model):
     _name = "hr.course.schedule"
     _description = "Course Schedule"
-    _inherit = "mail.thread"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
 
     name = fields.Char(required=True, tracking=True)
     course_id = fields.Many2one("hr.course", string="Course", required=True)

--- a/hr_course/views/hr_course_schedule_views.xml
+++ b/hr_course/views/hr_course_schedule_views.xml
@@ -144,6 +144,7 @@
                         widget="mail_followers"
                         groups="base.group_user"
                     />
+                    <field name="activity_ids" widget="mail_activity" />
                     <field name="message_ids" widget="mail_thread" />
                 </div>
             </form>


### PR DESCRIPTION
Filtering or searching by activities (activity_ids) on the model hr.course.schedule raises an exception because the model does not inherit from mail.activity.mixin.

@etobella 