### PR TITLE
[18.0][FIX] hr_employee_relative: add compute value for fields impacted by the compute method

### DIFF
--- a/hr_employee_relative/models/hr_employee_relative.py
+++ b/hr_employee_relative/models/hr_employee_relative.py
@@ -24,8 +24,8 @@ class HrEmployeeRelative(models.Model):
     )
     date_of_birth = fields.Date()
     age_year = fields.Integer(string="Age (Years)", compute="_compute_age")
-    age_month = fields.Integer(string="Age (Months)")
-    age_day = fields.Integer(string="Age (Days)")
+    age_month = fields.Integer(string="Age (Months)", compute="_compute_age")
+    age_day = fields.Integer(string="Age (Days)", compute="_compute_age")
 
     job = fields.Char()
     phone_number = fields.Char()


### PR DESCRIPTION
the method "_compute_age" assign values to the fields "age_month" and "age_day", but those fields are not marked as computed.
Therefore, when you have no write rights on the record, displaying "age_year" will end up in an access error