### PR TITLE
[FIX] hr_personal_equipment_request_tier_validation: Fix xpath

### DIFF
--- a/hr_personal_equipment_request_tier_validation/models/hr_personal_equipment_request.py
+++ b/hr_personal_equipment_request_tier_validation/models/hr_personal_equipment_request.py
@@ -9,7 +9,7 @@ class HrPersonalEquipmentRequest(models.Model):
     _name = "hr.personal.equipment.request"
     _inherit = ["hr.personal.equipment.request", "tier.validation"]
     _tier_validation_manual_config = False
-    _tier_validation_buttons_xpath = "/form/header/button[last()-1]"
+    _tier_validation_buttons_xpath = "/form/header/button[@name='cancel_request']"
 
     _state_to = ["accepted"]
     _cancel_state = "cancelled"


### PR DESCRIPTION
If you access as a base user (not hr user) you don't see the approval button.

Before:

![image](https://github.com/user-attachments/assets/5adc8133-30b8-44c1-8aee-b17214b8298d)

After:

![image](https://github.com/user-attachments/assets/1d315f95-c653-4e9b-b9da-9169036c4bc2)

The position of the button has been moved in order to apply the fix