### PR TITLE
[17.0][IMP] hr_employee_medical_examination: changes & imrpovements

### DIFF
--- a/hr_employee_medical_examination/models/hr_employee_medical_examination.py
+++ b/hr_employee_medical_examination/models/hr_employee_medical_examination.py
@@ -46,6 +46,11 @@ class HrEmployeeMedicalExamination(models.Model):
     year = fields.Char(default=lambda r: str(datetime.date.today().year))
 
     note = fields.Text(tracking=True)
+    address_id = fields.Many2one(
+        "res.partner",
+        tracking=True,
+        default=lambda self: self.env.company.partner_id.id,
+    )
 
     @api.onchange("date")
     def _onchange_date(self):

--- a/hr_employee_medical_examination/models/hr_employee_medical_examination.py
+++ b/hr_employee_medical_examination/models/hr_employee_medical_examination.py
@@ -27,7 +27,7 @@ class HrEmployeeMedicalExamination(models.Model):
         tracking=True,
     )
 
-    date = fields.Date(
+    date = fields.Datetime(
         string="Examination Date",
         tracking=True,
     )

--- a/hr_employee_medical_examination/tests/test_hr_employee_medical_examination.py
+++ b/hr_employee_medical_examination/tests/test_hr_employee_medical_examination.py
@@ -31,7 +31,14 @@ class TestHrEmployeeMedicalExamination(BaseCommon):
 
     def test_hr_employee_medical_examination(self):
         self.assertFalse(self.wizard.employee_ids)
-        self.wizard.write({"job_id": self.job.id, "department_id": self.department.id})
+        self.assertEqual(self.wizard.address_id, self.env.company.partner_id)
+        self.wizard.write(
+            {
+                "job_id": self.job.id,
+                "department_id": self.department.id,
+                "address_id": False,
+            }
+        )
         self.wizard.populate()
         self.assertEqual(len(self.wizard.employee_ids), 1)
         result = self.wizard.create_medical_examinations()
@@ -44,6 +51,7 @@ class TestHrEmployeeMedicalExamination(BaseCommon):
         self.assertEqual(examination.name, "Examination 2019 on Employee 1")
         self.assertEqual(self.employee1.medical_examination_count, 2)
         self.assertTrue(self.employee1.can_see_examinations_button)
+        self.assertFalse(examination.address_id)
         examination.write({"date": "2018-05-05"})
         examination._onchange_date()
         self.assertEqual(examination.year, "2018")

--- a/hr_employee_medical_examination/views/hr_employee_medical_examination_views.xml
+++ b/hr_employee_medical_examination/views/hr_employee_medical_examination_views.xml
@@ -54,6 +54,7 @@
                         </group>
                         <group>
                             <field name="result" />
+                            <field name="address_id" context="{'show_address': 1}" />
                         </group>
                     </group>
                     <div>

--- a/hr_employee_medical_examination/wizards/wizard_generate_medical_examination.py
+++ b/hr_employee_medical_examination/wizards/wizard_generate_medical_examination.py
@@ -24,6 +24,9 @@ class WizardGenerateMedicalExamination(models.TransientModel):
         comodel_name="hr.job",
         string="Job",
     )
+    address_id = fields.Many2one(
+        "res.partner", default=lambda self: self.env.company.partner_id.id
+    )
 
     def _prepare_employee_domain(self):
         res = []
@@ -57,6 +60,7 @@ class WizardGenerateMedicalExamination(models.TransientModel):
             },
             "employee_id": employee.id,
             "year": self.year,
+            "address_id": self.address_id.id,
         }
 
     def create_medical_examinations(self):

--- a/hr_employee_medical_examination/wizards/wizard_generate_medical_examination.xml
+++ b/hr_employee_medical_examination/wizards/wizard_generate_medical_examination.xml
@@ -12,6 +12,7 @@
                 <group>
                     <group>
                         <field name="name" />
+                        <field name="address_id" context="{'show_address': 1}" />
                     </group>
                     <group>
                         <field name="year" />


### PR DESCRIPTION
Hello,

We have made some changes to the `hr_employee_medical_examination` module. The updates/improvements are as follows:

- We have changed the examination date field from `date` to `datetime`. This allows specifying an exact time for the medical examination.
- We have added the ability to set an examination location (`res.partner`) to indicate where the examination will take place. By default, this field will be populated with the partner associated with the company.

We are also working on an improvement that will allow us to send a reminder to the employee, indicating when and where their medical examination will take place.

Any suggestions are welcome.

@Loregs2 @jaenbox 