### PR TITLE
[16.0][FIX] hr_employee_medical_examination: Use _for_xml_id() to avoid access errors

### DIFF
--- a/hr_employee_medical_examination/tests/test_hr_employee_medical_examination.py
+++ b/hr_employee_medical_examination/tests/test_hr_employee_medical_examination.py
@@ -1,30 +1,26 @@
 # Copyright 2019 Creu Blanca
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestHrEmployeeMedicalExamination(TransactionCase):
-    def setUp(self):
-        super().setUp()
-
-        self.department = self.env["hr.department"].create({"name": "Department"})
-
-        self.job = self.env["hr.job"].create({"name": "Job"})
-
-        self.employee1 = self.env["hr.employee"].create(
+class TestHrEmployeeMedicalExamination(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.department = cls.env["hr.department"].create({"name": "Department"})
+        cls.job = cls.env["hr.job"].create({"name": "Job"})
+        cls.employee1 = cls.env["hr.employee"].create(
             {
                 "name": "Employee 1",
-                "job_id": self.job.id,
-                "department_id": self.department.id,
+                "job_id": cls.job.id,
+                "department_id": cls.department.id,
             }
         )
-
-        self.examination = self.env["hr.employee.medical.examination"].create(
-            {"name": "Dummy Exam to test domain", "employee_id": self.employee1.id}
+        cls.examination = cls.env["hr.employee.medical.examination"].create(
+            {"name": "Dummy Exam to test domain", "employee_id": cls.employee1.id}
         )
-
-        self.wizard = self.env["wizard.generate.medical.examination"].create(
+        cls.wizard = cls.env["wizard.generate.medical.examination"].create(
             {"name": "Examination 2019"}
         )
 

--- a/hr_employee_medical_examination/wizards/wizard_generate_medical_examination.py
+++ b/hr_employee_medical_examination/wizards/wizard_generate_medical_examination.py
@@ -67,11 +67,8 @@ class WizardGenerateMedicalExamination(models.TransientModel):
                 exams |= self.env["hr.employee.medical.examination"].create(
                     form._create_examination_vals(employee)
                 )
-        action = self.env.ref(
-            "hr_employee_medical_examination.hr_employee"
-            "_medical_examination_act_window",
-            False,
+        result = self.env["ir.actions.act_window"]._for_xml_id(
+            "hr_employee_medical_examination.hr_employee_medical_examination_act_window"
         )
-        result = action.read()[0]
         result["domain"] = [("id", "in", exams.ids)]
         return result


### PR DESCRIPTION
Changes done:
- [x] Use `_for_xml_id()` to avoid access errors.
- [x] Change `TransactionCase` to `BaseCommon`

Please @pedrobaeza can you review it?

@Tecnativa TT56829
