### PR TITLE
[17.0][FIX] hr_employee_medical_examination: Use _for_xml_id() to avoid access errors

### DIFF
--- a/hr_employee_medical_examination/wizards/wizard_generate_medical_examination.py
+++ b/hr_employee_medical_examination/wizards/wizard_generate_medical_examination.py
@@ -66,11 +66,8 @@ class WizardGenerateMedicalExamination(models.TransientModel):
                 exams |= self.env["hr.employee.medical.examination"].create(
                     form._create_examination_vals(employee)
                 )
-        action = self.env.ref(
-            "hr_employee_medical_examination.hr_employee"
-            "_medical_examination_act_window",
-            False,
+        result = self.env["ir.actions.act_window"]._for_xml_id(
+            "hr_employee_medical_examination.hr_employee_medical_examination_act_window"
         )
-        result = action.read()[0]
         result["domain"] = [("id", "in", exams.ids)]
         return result


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/hr/pull/1480

Use `_for_xml_id()` to avoid access errors.

Please @pedrobaeza can you review it?

@Tecnativa TT56829
