### PR TITLE
[18.0][FIX] hr_employee_firstname: Use work_contact_id instead of address_home_id

### DIFF
--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -9,7 +9,7 @@ from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
-UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "address_home_id"]
+UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "work_contact_id"]
 
 
 class HrEmployee(models.Model):
@@ -168,7 +168,7 @@ class HrEmployee(models.Model):
     def _update_partner_firstname(self):
         for employee in self:
             partners = employee.mapped("user_id.partner_id")
-            partners |= employee.mapped("address_home_id")
+            partners |= employee.mapped("work_contact_id")
             partners.write(
                 {"firstname": employee.firstname, "lastname": employee.lastname}
             )


### PR DESCRIPTION
Changes to adapt the module as per changes in base Odoo module in https://github.com/odoo/odoo/commit/e8c48f824e078d643a3385fb910707d5525e927d