### PR TITLE
[18.0][FIX]hr_employee_calendar_planning: Fix _check_company_id

### DIFF
--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -39,6 +39,7 @@ class ResourceCalendar(models.Model):
         for item in self.filtered("company_id"):
             total_items = self.env["hr.employee.calendar"].search_count(
                 [
+                    ("calendar_id", "=", item.id),
                     ("calendar_id.company_id", "=", item.company_id.id),
                     ("employee_id.company_id", "!=", item.company_id.id),
                     ("employee_id.company_id", "!=", False),


### PR DESCRIPTION
v18 version of #1491 

The check does not consider the calendar itself. It only checks if any calendar has inconsistency with companies.

Steps to reproduce:
1. Create second company (If only one exists)
2. Change the company of any employee with a Working time (for example Abigail Peterson)
3. Go to working times
4. Create a new working time
5. Click save

The Validation Error of _check_company_id of resource.calendar is shown. The new resource.calendar is currently not used for any employee. The Error should not be thrown. 