### PR TITLE
[18.0][FIX] hr_employee_second_lastname: Use work_contact_id instead …

### DIFF
--- a/hr_employee_second_lastname/models/hr_employee.py
+++ b/hr_employee_second_lastname/models/hr_employee.py
@@ -75,7 +75,7 @@ class HrEmployee(models.Model):
     def _update_partner_firstname(self):
         for employee in self:
             partners = employee.mapped("user_id.partner_id")
-            partners |= employee.mapped("address_home_id")
+            partners |= employee.mapped("work_contact_id")
             partners.write(
                 {
                     "firstname": employee.firstname,


### PR DESCRIPTION
…of address_home_id