### PR TITLE
[16.0][IMP] hr_employee_ppe: Using related fields

### DIFF
--- a/hr_employee_ppe/models/hr_personal_equipment.py
+++ b/hr_employee_ppe/models/hr_personal_equipment.py
@@ -14,11 +14,15 @@ class HrPersonalEquipment(models.Model):
     _name = "hr.personal.equipment"
     _inherit = ["hr.personal.equipment"]
 
-    is_ppe = fields.Boolean()
+    is_ppe = fields.Boolean(related="product_id.is_ppe", store=True)
     indications = fields.Text(
         help="Situations in which the employee should use this equipment.",
+        related="product_id.indications",
+        store=True,
     )
-    expire_ppe = fields.Boolean(help="True if the PPE expires")
+    expire_ppe = fields.Boolean(
+        help="True if the PPE expires", related="product_id.expirable_ppe", store=True
+    )
     certification = fields.Char(
         string="Certification Number", help="Certification Number"
     )
@@ -28,16 +32,6 @@ class HrPersonalEquipment(models.Model):
         res = super()._accept_request_vals()
         res["issued_by"] = self.env.user.id
         return res
-
-    @api.onchange("product_id")
-    def _compute_fields(self):
-        for rec in self:
-            if rec.product_id.is_ppe:
-                rec.is_ppe = rec.product_id.is_ppe
-                if rec.product_id.expirable_ppe:
-                    rec.expire_ppe = rec.product_id.expirable_ppe
-                if rec.product_id.indications:
-                    rec.indications = rec.product_id.indications
 
     def _validate_allocation_vals(self):
         res = super()._validate_allocation_vals()

--- a/hr_employee_ppe/tests/test_hr_employee_ppe.py
+++ b/hr_employee_ppe/tests/test_hr_employee_ppe.py
@@ -81,15 +81,6 @@ class TestHREmployeePPE(TransactionCase):
         cls.hr_employee_ppe_expirable = cls.personal_equipment_request.line_ids[0]
         cls.hr_employee_ppe_no_expirable = cls.personal_equipment_request.line_ids[1]
 
-    def test_compute_fields(self):
-        self.hr_employee_ppe_expirable._compute_fields()
-        self.assertTrue(self.hr_employee_ppe_expirable.is_ppe)
-        self.assertTrue(self.hr_employee_ppe_expirable.expire_ppe)
-        self.assertEqual(
-            self.hr_employee_ppe_expirable.indications,
-            self.product_employee_ppe_expirable.indications,
-        )
-
     def test_accept_allocation(self):
         self.assertFalse(self.hr_employee_ppe_expirable.issued_by)
         self.personal_equipment_request.with_user(self.user).accept_request()
@@ -139,10 +130,15 @@ class TestHREmployeePPE(TransactionCase):
         self.assertNotEqual(self.hr_employee_ppe_no_expirable.state, "expired")
 
     def test_check_dates(self):
+        self.hr_employee_ppe_expirable.start_date = "2020-01-01"
+        self.hr_employee_ppe_expirable.expiry_date = "2019-12-31"
+        self.assertTrue(self.hr_employee_ppe_expirable.is_ppe)
+        self.assertTrue(self.hr_employee_ppe_expirable.expire_ppe)
+        self.assertEqual(
+            self.hr_employee_ppe_expirable.indications,
+            self.product_employee_ppe_expirable.indications,
+        )
         with self.assertRaises(ValidationError):
-            self.hr_employee_ppe_expirable.start_date = "2020-01-01"
-            self.hr_employee_ppe_expirable.expiry_date = "2019-12-31"
-            self.hr_employee_ppe_expirable._compute_fields()
             self.hr_employee_ppe_expirable.validate_allocation()
 
     def test_compute_contains_ppe(self):


### PR DESCRIPTION
   Using related fields for "is_ppe", "expire_ppe"
and "indications" instead of computing these fields based on product change from UI.