### PR TITLE
[19.0][FIX] hr_employee_fistname error with permisions

### DIFF
--- a/hr_employee_firstname/README.rst
+++ b/hr_employee_firstname/README.rst
@@ -76,6 +76,7 @@ Contributors
 - Adrien Peiffer (ACSONE) <adrien.peiffer@acsone.eu>
 - Antonio Esposito (ONESTEIN BV) <a.esposito@onestein.nl>
 - Andrea Stirpe <a.stirpe@onestein.nl>
+- Vicent Castells <vicent@studio73.es>
 
 Maintainers
 -----------

--- a/hr_employee_firstname/models/__init__.py
+++ b/hr_employee_firstname/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import base_config_settings
 from . import hr_employee
+from . import hr_employee_public

--- a/hr_employee_firstname/models/hr_employee_public.py
+++ b/hr_employee_firstname/models/hr_employee_public.py
@@ -1,0 +1,11 @@
+# Copyright 2026 Studio73 (<https://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+    _inherit = "hr.employee.public"
+
+    firstname = fields.Char(related="employee_id.firstname")
+    lastname = fields.Char(related="employee_id.lastname")

--- a/hr_employee_firstname/readme/CONTRIBUTORS.md
+++ b/hr_employee_firstname/readme/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 - Adrien Peiffer (ACSONE) \<<adrien.peiffer@acsone.eu>\>
 - Antonio Esposito (ONESTEIN BV) \<<a.esposito@onestein.nl>\>
 - Andrea Stirpe \<<a.stirpe@onestein.nl>\>
+- Vicent Castells \<<vicent@studio73.es>\>

--- a/hr_employee_firstname/static/description/index.html
+++ b/hr_employee_firstname/static/description/index.html
@@ -423,6 +423,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Adrien Peiffer (ACSONE) &lt;<a class="reference external" href="mailto:adrien.peiffer&#64;acsone.eu">adrien.peiffer&#64;acsone.eu</a>&gt;</li>
 <li>Antonio Esposito (ONESTEIN BV) &lt;<a class="reference external" href="mailto:a.esposito&#64;onestein.nl">a.esposito&#64;onestein.nl</a>&gt;</li>
 <li>Andrea Stirpe &lt;<a class="reference external" href="mailto:a.stirpe&#64;onestein.nl">a.stirpe&#64;onestein.nl</a>&gt;</li>
+<li>Vicent Castells &lt;<a class="reference external" href="mailto:vicent&#64;studio73.es">vicent&#64;studio73.es</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
If the user are not in hr.group_hr_user but is in other group like hr_expense.group_hr_expense_manager if you try to go in,  it raise this error because the fields defined in hr.employee are not defined in the public model and are not reachable

<img width="1137" height="199" alt="image" src="https://github.com/user-attachments/assets/eb12968a-6fda-46c2-9fbf-1088589cea75" />
