### PR TITLE
[19.0][FIX] hr_employee_firstname: firstname and lastname shouldn't be fetched when accessing hr.employee.public

### DIFF
--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -15,8 +15,8 @@ UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "address_home_id"]
 class HrEmployee(models.Model):
     _inherit = "hr.employee"
 
-    firstname = fields.Char()
-    lastname = fields.Char()
+    firstname = fields.Char(groups="hr.group_hr_user")
+    lastname = fields.Char(groups="hr.group_hr_user")
 
     @api.model
     def _names_order_default(self):


### PR DESCRIPTION
## Context

After migration of `hr_employee_firstname` to 19, a bug has been introduced:

When accessing model "hr.employee.public" (accessing employee infos without hr rights), `firstname` and `lastname` are automatically fetched.

For example when opening an expense with a user that hasn't hr rights:
<img width="994" height="246" alt="image" src="https://github.com/user-attachments/assets/30cc6d96-3bd2-4ef8-b996-4dd066177f90" />

## Solution

We have two options:
- Add the field on "hr.employee.public"
- Set a group on those fields to avoid fetching these fields when having small rights.

**I chose the second option** because firstname/lastname aren't present in "hr.employee.public" views and therefore, it shouldn't be fetched.


