### PR TITLE
[FIX] hr_employee_second_lastname: fix access error when reading employees public info

### DIFF
--- a/hr_employee_second_lastname/models/__init__.py
+++ b/hr_employee_second_lastname/models/__init__.py
@@ -1,1 +1,2 @@
 from . import hr_employee
+from . import hr_employee_public

--- a/hr_employee_second_lastname/models/hr_employee_public.py
+++ b/hr_employee_second_lastname/models/hr_employee_public.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+    _inherit = "hr.employee.public"
+
+    lastname2 = fields.Char(related="employee_id.lastname2")


### PR DESCRIPTION
In v19, hr.employee.base was removed [1] and lastname2 was moved back to `hr.employee` but did not replicate it on `hr.employee.public`.

Since lastname2 is part of the employee display name and not sensitive data, declare it as a related field on hr.employee.public so non-HR users can read employees without triggering an AccessError.

[1]: https://github.com/OCA/hr/commit/d2e5fe75