### PR TITLE
[FIX] hr_employee_second_lastname: expose lastname2 on public

### DIFF
--- a/hr_employee_second_lastname/models/__init__.py
+++ b/hr_employee_second_lastname/models/__init__.py
@@ -1,1 +1,2 @@
 from . import hr_employee
+from . import hr_employee_public

--- a/hr_employee_second_lastname/models/hr_employee_public.py
+++ b/hr_employee_second_lastname/models/hr_employee_public.py
@@ -1,0 +1,10 @@
+# Copyright 2026 Vauxoo (<https://www.vauxoo.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+    _inherit = "hr.employee.public"
+
+    lastname2 = fields.Char(related="employee_id.lastname2")


### PR DESCRIPTION
The field lastname2 was not available on hr.employee.public, causing the error 'fields are not available for employee public profiles' when non-HR users accessed employee records.

This follows the same approach used in hr_employee_firstname commit 51c92d0 which exposed firstname and lastname on the public model but missed lastname2 from this module.