### PR TITLE
[16.0][FIX]hr_employee_firstname_partner_firstname:

### DIFF
--- a/hr_employee_firstname_partner_firstname/__manifest__.py
+++ b/hr_employee_firstname_partner_firstname/__manifest__.py
@@ -12,5 +12,5 @@
     "summary": "Glue module between partner_firstname and hr_employee_firstname",
     "depends": ["hr_employee_firstname", "partner_firstname"],
     "installable": True,
-    "autoinstall": True,
+    "auto_install": True,
 }


### PR DESCRIPTION
### Description
                                                     
A technical issue was identified in the manifest of `hr_employee_firstname_partner_firstname`. The module declares "autoinstall": True instead of the expected "auto_install": True, so Odoo silently ignores the key and the glue never installs automatically when its dependencies are present.

###  Cases Covered with This Improvement

This update introduces a single fix to restore the  documented behavior of the module:
                                                     
- Manifest key correction: the autoinstall key is renamed to auto_install so Odoo recognizes the auto-install hint. 

 ### Implemented Solution                               
   
This issue was resolved by editing the manifest of the module: the misspelled autoinstall key in `hr_employee_firstname_partner_firstname/__manifest__.py `was replaced with the canonical auto_install key supported by Odoo. No code changes are needed in models, views, or hooks — the fix is a single-line manifest correction.
  
  FL-556-8479