### PR TITLE
[FIX] hr_employee_firstname: address_home_id -> work_contact_id (V19 compat)

### DIFF
--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -9,7 +9,7 @@ from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
-UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "address_home_id"]
+UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "work_contact_id"]
 
 
 class HrEmployee(models.Model):
@@ -171,7 +171,7 @@ class HrEmployee(models.Model):
     def _update_partner_firstname(self):
         for employee in self:
             partners = employee.mapped("user_id.partner_id")
-            partners |= employee.mapped("address_home_id")
+            partners |= employee.mapped("work_contact_id")
             partners.write(
                 {"firstname": employee.firstname, "lastname": employee.lastname}
             )


### PR DESCRIPTION
## Description

`hr_employee_firstname` on the `19.0` branch still references `hr.employee.address_home_id`, which was **removed in Odoo 19** (HR refactoring — the private contact link is now `work_contact_id`).

Without this fix, the module crashes on a fresh V19 install / runtime as soon as `_update_partner_firstname` is triggered (or `UPDATE_PARTNER_FIELDS` is read) because `address_home_id` does not exist on `hr.employee` anymore.

## Changes

```diff
- UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "address_home_id"]
+ UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "work_contact_id"]

  def _update_partner_firstname(self):
      for employee in self:
          partners = employee.mapped("user_id.partner_id")
-         partners |= employee.mapped("address_home_id")
+         partners |= employee.mapped("work_contact_id")
```

## Context

Discovered while migrating a large Odoo V12 → V19 deployment (Reanova ERP). The patch has been running in production-like staging for several days without issue.

`work_contact_id` is the V18+ Odoo replacement for the V12-V17 `address_home_id` field on `hr.employee` (cf. Odoo 18 release notes — HR module overhaul).

## Tests

Manual test on a V19 install with ~180 employees + `partner_firstname` dependency: employees update their partner records (firstname/lastname) correctly through `_update_partner_firstname` after this change. No regression observed on related modules (`hr_employee_legal_name`, etc.).
