### PR TITLE
[18.0][FIX] hr_contract_employee_calendar_planning: Avoid making changes to contracts based on the appropriate calendar

### DIFF
--- a/hr_contract_employee_calendar_planning/hooks.py
+++ b/hr_contract_employee_calendar_planning/hooks.py
@@ -12,6 +12,8 @@ def post_init_hook(env):
     for employee in employees.filtered("contract_ids"):
         contract_calendar_lines = []
         for contract in employee.contract_ids.sorted("date_start"):
+            if contract.resource_calendar_id == employee.resource_calendar_id:
+                continue
             date_start = contract.date_start
             date_end = contract.date_end
             # filter calendar_ids to check for overlaps with contracts

--- a/hr_contract_employee_calendar_planning/tests/test_hr_contract_employee_calendar_planning.py
+++ b/hr_contract_employee_calendar_planning/tests/test_hr_contract_employee_calendar_planning.py
@@ -72,9 +72,11 @@ class TestHrContractEmployeeCalendarPlanning(
         self.env.cr.execute(
             f"UPDATE hr_contract SET resource_calendar_id = {self.calendar1.id} WHERE id = {self.contract_1.id}"  # noqa: E501
         )
+        self.contract_1.invalidate_recordset(["resource_calendar_id"])
         self.env.cr.execute(
             f"UPDATE hr_contract SET resource_calendar_id = {self.calendar2.id} WHERE id = {self.contract_2.id}"  # noqa: E501
         )
+        self.contract_2.invalidate_recordset(["resource_calendar_id"])
         # calendar migration from contracts
         old_calendars = self.employee.calendar_ids
         post_init_hook(self.env)
@@ -103,9 +105,11 @@ class TestHrContractEmployeeCalendarPlanning(
         self.env.cr.execute(
             f"UPDATE hr_contract SET resource_calendar_id = {self.calendar1.id} WHERE id = {self.contract_1.id}"  # noqa: E501
         )
+        self.contract_1.invalidate_recordset(["resource_calendar_id"])
         self.env.cr.execute(
             f"UPDATE hr_contract SET resource_calendar_id = {self.calendar2.id} WHERE id = {self.contract_2.id}"  # noqa: E501
         )
+        self.contract_2.invalidate_recordset(["resource_calendar_id"])
         # calendar migration from contracts
         old_calendars = self.employee.calendar_ids
         post_init_hook(self.env)


### PR DESCRIPTION
Avoid making changes to contracts based on the appropriate calendar

If the contracts use the same (auto-generated) calendar as the employee, do not make any changes to those contracts when installing the module

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT63452