### PR TITLE
[17.0][ADD] hr_course: add company_id multi-company support

### DIFF
--- a/hr_course/__manifest__.py
+++ b/hr_course/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "HR Course",
     "summary": """
         This module allows your to manage employee's training courses""",
-    "version": "17.0.1.0.1",
+    "version": "17.0.1.1.0",
     "license": "AGPL-3",
     "author": "Creu Blanca, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/hr",

--- a/hr_course/i18n/hr_course.pot
+++ b/hr_course/i18n/hr_course.pot
@@ -116,6 +116,13 @@ msgid "Comment"
 msgstr ""
 
 #. module: hr_course
+#: model:ir.model.fields,field_description:hr_course.field_hr_course__company_id
+#: model:ir.model.fields,field_description:hr_course.field_hr_course_attendee__company_id
+#: model:ir.model.fields,field_description:hr_course.field_hr_course_schedule__company_id
+msgid "Company"
+msgstr ""
+
+#. module: hr_course
 #: model_terms:ir.ui.view,arch_db:hr_course.hr_course_schedule_form_view
 msgid "Complete Course"
 msgstr ""

--- a/hr_course/models/hr_course.py
+++ b/hr_course/models/hr_course.py
@@ -26,6 +26,13 @@ class HRCourseAttendee(models.Model):
         default="pending",
     )
     active = fields.Boolean(default=True, readonly=True)
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        related="course_schedule_id.company_id",
+        store=True,
+        readonly=True,
+    )
 
     def _remove_from_course(self):
         return [(1, self.id, {"active": False})]
@@ -39,6 +46,9 @@ class HrCourse(models.Model):
     name = fields.Char(required=True, tracking=True)
     category_id = fields.Many2one(
         "hr.course.category", string="Category", required=True
+    )
+    company_id = fields.Many2one(
+        "res.company", string="Company", default=lambda self: self.env.company
     )
 
     permanence = fields.Boolean(string="Has Permanence", default=False, tracking=True)

--- a/hr_course/models/hr_course_schedule.py
+++ b/hr_course/models/hr_course_schedule.py
@@ -22,6 +22,9 @@ class HrCourseSchedule(models.Model):
         string="Currency",
         default=lambda self: self.env.user.company_id.currency_id,
     )
+    company_id = fields.Many2one(
+        "res.company", string="Company", default=lambda self: self.env.company
+    )
     cost = fields.Monetary(string="Course Cost", required=True, tracking=True)
     authorized_by = fields.Many2one(
         comodel_name="hr.employee",

--- a/hr_course/security/course_security.xml
+++ b/hr_course/security/course_security.xml
@@ -32,4 +32,25 @@
         <field name="groups" eval="[(4, ref('hr.group_hr_manager'))]" />
         <field name="global" eval="False" />
     </record>
+    <record model="ir.rule" id="hr_course_rule_company">
+        <field name="name">HR Course Multi-Company</field>
+        <field name="model_id" ref="model_hr_course" />
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+    <record model="ir.rule" id="hr_course_schedule_rule_company">
+        <field name="name">HR Course Schedule Multi-Company</field>
+        <field name="model_id" ref="model_hr_course_schedule" />
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+    <record model="ir.rule" id="hr_course_attendee_rule_company">
+        <field name="name">HR Course Attendee Multi-Company</field>
+        <field name="model_id" ref="model_hr_course_attendee" />
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
 </odoo>

--- a/hr_course/views/hr_course_schedule_views.xml
+++ b/hr_course/views/hr_course_schedule_views.xml
@@ -85,7 +85,6 @@
                     </div>
                     <group>
                         <group>
-                            <field name="company_id" invisible="1" />
                             <field name="course_id" />
                             <field
                                 name="cost"

--- a/hr_course/views/hr_course_schedule_views.xml
+++ b/hr_course/views/hr_course_schedule_views.xml
@@ -85,6 +85,7 @@
                     </div>
                     <group>
                         <group>
+                            <field name="company_id" invisible="1" />
                             <field name="course_id" />
                             <field
                                 name="cost"
@@ -100,6 +101,11 @@
                             <field name="instructor_ids" widget="many2many_tags" />
                             <field name="place" />
                             <field name="comment" />
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                                options="{'no_create': True}"
+                            />
                         </group>
                         <group>
                             <field name="start_date" readonly="state !='draft'" />
@@ -175,6 +181,11 @@
                 <field name="start_date" />
                 <field name="end_date" />
                 <field name="state" />
+                <field
+                    name="company_id"
+                    optional="hide"
+                    groups="base.group_multi_company"
+                />
             </tree>
         </field>
     </record>

--- a/hr_course/views/hr_course_views.xml
+++ b/hr_course/views/hr_course_views.xml
@@ -15,7 +15,6 @@
                     </div>
                     <group>
                         <group>
-                            <field name="company_id" invisible="1" />
                             <field name="category_id" />
                             <field name="permanence" />
                             <field name="permanence_time" invisible="not permanence" />

--- a/hr_course/views/hr_course_views.xml
+++ b/hr_course/views/hr_course_views.xml
@@ -15,9 +15,15 @@
                     </div>
                     <group>
                         <group>
+                            <field name="company_id" invisible="1" />
                             <field name="category_id" />
                             <field name="permanence" />
                             <field name="permanence_time" invisible="not permanence" />
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                                options="{'no_create': True}"
+                            />
                         </group>
                     </group>
                     <notebook>
@@ -69,6 +75,11 @@
                 <field name="category_id" />
                 <field name="content" />
                 <field name="objective" />
+                <field
+                    name="company_id"
+                    optional="hide"
+                    groups="base.group_multi_company"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
This PR adds multi-company support to the hr_course module by adding a stored `company_id` field on `hr.course`, `hr.course.schedule`, and `hr.course.attendee`, along with global multi-company ir.rules and the corresponding views.