### PR TITLE
[17.0][FIX] hr_course: show results on completed schedules

### DIFF
--- a/hr_course/models/hr_course_schedule.py
+++ b/hr_course/models/hr_course_schedule.py
@@ -118,14 +118,13 @@ class HrCourseSchedule(models.Model):
 
     def validation2complete(self):
         for record in self:
-            if self.course_attendee_ids.filtered(
+            if record.course_attendee_ids.filtered(
                 lambda r: r.result == "pending" and r.active
             ):
                 raise ValidationError(
                     _("You cannot complete the course with pending results")
                 )
-            else:
-                record.write(record._validation2complete_values())
+            record.write(record._validation2complete_values())
 
     def back2draft(self):
         for record in self:

--- a/hr_course/tests/test_hr_course.py
+++ b/hr_course/tests/test_hr_course.py
@@ -75,3 +75,31 @@ class TestHrCourse(common.TransactionCase):
         )
         self.course_schedule_id.validation2complete()
         self.assertEqual(self.course_schedule_id.state, "completed")
+
+    def test_validation2complete_multi_record(self):
+        self.course_schedule_id.draft2waiting()
+        self.course_schedule_id.attendant_ids = [(6, 0, [self.employee1.id])]
+        self.course_schedule_id.waiting2inprogress()
+        self.course_schedule_id.inprogress2validation()
+        self.course_schedule_id.all_passed()
+
+        course_schedule_2 = self.env["hr.course.schedule"].create(
+            {
+                "name": "Convocatory 2",
+                "course_id": self.course_id.id,
+                "cost": 100,
+                "authorized_by": self.employee1.id,
+            }
+        )
+        course_schedule_2.draft2waiting()
+        course_schedule_2.attendant_ids = [(6, 0, [self.employee2.id])]
+        course_schedule_2.waiting2inprogress()
+        course_schedule_2.inprogress2validation()
+
+        with self.assertRaises(ValidationError):
+            (self.course_schedule_id | course_schedule_2).validation2complete()
+
+        course_schedule_2.all_passed()
+        (self.course_schedule_id | course_schedule_2).validation2complete()
+        self.assertEqual(self.course_schedule_id.state, "completed")
+        self.assertEqual(course_schedule_2.state, "completed")

--- a/hr_course/views/hr_course_schedule_views.xml
+++ b/hr_course/views/hr_course_schedule_views.xml
@@ -133,7 +133,8 @@
                             <field
                                 name="course_attendee_ids"
                                 widget="one2many_list"
-                                invisible="state not in ['in_validation']"
+                                invisible="state not in ['in_progress','in_validation','completed']"
+                                readonly="state != 'in_validation'"
                             />
                         </page>
                         <page


### PR DESCRIPTION
**Issue:** Once a course schedule reaches the "completed" state, the *Course Results* page is visible but empty because the attendee list is only shown in the "in_validation" state.

**Fix:** Show the attendee results list whenever the *Course Results* page is visible (in_progress, in_validation, completed) and make it editable only during validation.

Also fixes a minor bug in `validation2complete()` where `self` was used instead of `record` inside the loop, so pending results were not checked per record when completing multiple schedules at once.

Test added for the multi-record case.