### PR TITLE
[17.0][FIX] hr_course: align schedule tree decoration with Odoo 17 guidelines

### DIFF
--- a/hr_course/views/hr_course_schedule_views.xml
+++ b/hr_course/views/hr_course_schedule_views.xml
@@ -167,14 +167,18 @@
         <field name="name">hr.course.schedule.tree</field>
         <field name="model">hr.course.schedule</field>
         <field name="arch" type="xml">
-            <tree
-                decoration-success="state=='completed'"
-                decoration-muted="state=='cancelled'"
-            >
+            <tree>
                 <field name="name" />
                 <field name="start_date" />
                 <field name="end_date" />
-                <field name="state" />
+                <field
+                    name="state"
+                    widget="badge"
+                    decoration-info="state == 'draft'"
+                    decoration-warning="state in ('waiting_attendees', 'in_progress', 'in_validation')"
+                    decoration-success="state == 'completed'"
+                    decoration-muted="state == 'cancelled'"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Before this commit, the course schedule tree view colored entire rows based on the state (success for completed, muted for cancelled).

Following Odoo core conventions, workflow state should be rendered as a per-field badge instead of coloring the whole row. This change:

- Removes row-level `decoration-success` and `decoration-muted` from the tree.
- Adds `widget="badge"` to the `state` field.
- Applies per-state decorations:
  - `draft` → info
  - `waiting_attendees`, `in_progress`, `in_validation` → warning
  - `completed` → success
  - `cancelled` → muted