### PR TITLE
[19.0][FIX] hr_employee_calendar_planning: Compatibility with hr_attendance_report_theoretical_time

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -136,7 +136,9 @@ class HrEmployee(models.Model):
         domain=None,
     ):
         # Override function that change the calendar depending on date
-        if len(self) == 1 and self.calendar_ids:
+        if calendar and len(self) == 1 and self.calendar_ids:
+            if from_datetime.tzinfo:
+                from_datetime = from_datetime.replace(tzinfo=None)
             from_dt_tz = fields.Datetime.context_timestamp(self, from_datetime)
             check_date = from_dt_tz.date()
             planned_line = self.calendar_ids.filtered(


### PR DESCRIPTION
This commit fixes two errors:
1. When from_datetime is passed from another location with a timezone set, the context_timestamp function raises an error:

`ValueError: Not naive datetime (tzinfo is already set)
`
**Steps to reproduce locally:**

- Install the hr_employee_calendar_planning and hr_attendance_report_theoretical_time modules. 
- Enable Attendances from Backend Settings / Attendances / Configuration  / Settings. 
- Set a calendar for the Mitchell Admin employee.
- Try to check in with the employee. A traceback is raised.

<img width="1729" height="1026" alt="image" src="https://github.com/user-attachments/assets/02bbc0f9-b3b1-412a-a842-f85f4fd3c6ee" />

2. When `_get_work_days_data_batch` is called without the calendar parameter, it finds and replaces the calendar with the best matching calendar from `calendar_ids`. However, if no calendar is passed, no calendar should be replaced. Currently, it takes the first calendar created automatically by the `hr_employee_calendar_planning` module and uses it to compute the data. This causes the tests in the `hr_attendance_report_theoretical_time` module to fail because no calendar is passed to the function.

**Steps to reproduce locally:**

- Install the `hr_employee_calendar_planning` and `hr_attendance_report_theoretical_time` modules.
- Run the hr_attendance_report_theoretical_time tests. They fail.

<img width="1253" height="940" alt="image" src="https://github.com/user-attachments/assets/f72cfda8-e30b-44cd-a128-e77c432b6dad" />

Complementary to https://github.com/OCA/hr/pull/1540/changes/929aa51a58d8cb192d80c0cd7eac6167db119170

TT64060
@Tecnativa @pedrobaeza @victoralmau @Vicent-C6 @alexey-pelykh could you please review this?
