### PR TITLE
[FIX] hr_employee_relative: add record rules to prevent cross-employee family PII disclosure

### DIFF
--- a/hr_employee_relative/__manifest__.py
+++ b/hr_employee_relative/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "HR Employee Relatives",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Human Resources",
     "website": "https://github.com/OCA/hr",
     "author": "CorporateHub, Odoo Community Association (OCA)",
@@ -17,6 +17,7 @@
     "data": [
         "data/data_relative_relation.xml",
         "security/ir.model.access.csv",
+        "security/hr_employee_relative_security.xml",
         "views/hr_employee.xml",
         "views/hr_employee_relative.xml",
     ],

--- a/hr_employee_relative/security/hr_employee_relative_security.xml
+++ b/hr_employee_relative/security/hr_employee_relative_security.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="hr_employee_relative_rule_own" model="ir.rule">
+        <field name="name">Employee relatives: own employee record only</field>
+        <field name="model_id" ref="model_hr_employee_relative" />
+        <field name="domain_force">[('employee_id.user_id', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+    </record>
+    <record id="hr_employee_relative_rule_hr" model="ir.rule">
+        <field name="name">Employee relatives: HR full access</field>
+        <field name="model_id" ref="model_hr_employee_relative" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('hr.group_hr_user'))]" />
+    </record>
+</odoo>

--- a/hr_employee_relative/tests/__init__.py
+++ b/hr_employee_relative/tests/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_hr_employee_relatives
+from . import test_hr_employee_relative_access

--- a/hr_employee_relative/tests/test_hr_employee_relative_access.py
+++ b/hr_employee_relative/tests/test_hr_employee_relative_access.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Grégory Mariani
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo.tests import common
+from odoo.tests.common import new_test_user
+
+
+class TestHrEmployeeRelativeAccess(common.TransactionCase):
+    """Regression test for the missing record rule on hr.employee.relative.
+
+    The model granted base.group_user read access with no ir.rule, so any
+    internal user could read every employee's family PII. A record rule now
+    scopes normal users to their own employee's relatives while HR keeps full
+    access.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Relative = cls.env["hr.employee.relative"]
+        cls.relation = cls.env.ref("hr_employee_relative.relation_sibling")
+        # A relative attached to an employee not linked to the plain user.
+        cls.other_employee = cls.env["hr.employee"].create({"name": "Other Employee"})
+        cls.foreign_relative = Relative.create(
+            {
+                "employee_id": cls.other_employee.id,
+                "relation_id": cls.relation.id,
+                "name": "Jane Secret",
+                "date_of_birth": "1990-05-01",
+                "phone_number": "+33600112233",
+                "notes": "confidential",
+            }
+        )
+        cls.plain_user = new_test_user(
+            cls.env, login="relative-plain", groups="base.group_user"
+        )
+        cls.hr_user = new_test_user(
+            cls.env,
+            login="relative-hr",
+            groups="base.group_user,hr.group_hr_user",
+        )
+        # An employee linked to the plain user, with its own relative.
+        cls.own_employee = cls.env["hr.employee"].create(
+            {"name": "Own Employee", "user_id": cls.plain_user.id}
+        )
+        cls.own_relative = Relative.create(
+            {
+                "employee_id": cls.own_employee.id,
+                "relation_id": cls.relation.id,
+                "name": "Own Relative",
+            }
+        )
+
+    def test_plain_user_cannot_read_foreign_relatives(self):
+        visible = self.env["hr.employee.relative"].with_user(self.plain_user).search([])
+        self.assertNotIn(
+            self.foreign_relative,
+            visible,
+            "a plain internal user must not read another employee's relatives",
+        )
+
+    def test_plain_user_reads_own_relatives(self):
+        visible = self.env["hr.employee.relative"].with_user(self.plain_user).search([])
+        self.assertIn(
+            self.own_relative,
+            visible,
+            "a user must still see the relatives of their own employee record",
+        )
+
+    def test_hr_user_reads_all_relatives(self):
+        visible = self.env["hr.employee.relative"].with_user(self.hr_user).search([])
+        self.assertIn(
+            self.foreign_relative,
+            visible,
+            "an HR user must retain full access to relatives",
+        )


### PR DESCRIPTION
## [FIX] hr_employee_relative: restrict relatives to own employee / HR

### Security impact

Missing authorization / over-permissive ACL (CWE-862), leading to disclosure of
family PII.

`hr.employee.relative` stores employees' family data (name, gender, date of
birth, phone number, job, free-text notes) as stored fields. Its ACL grants
`base.group_user` (every internal user) `perm_read = 1`, and the module ships
**no `ir.rule`**:

```csv
access_hr_employee_relative_employee,...,base.group_user,1,0,0,0
```

With no per-record scoping, **any authenticated internal user can `search_read`
the whole table over RPC and read every employee's relatives' personal data**,
with no HR permission and regardless of company. The backend view hides the data
behind `groups="hr..."`, but that is UI-only and does not protect the RPC
endpoint. `write/create/unlink` remain denied for `base.group_user`, so this is a
read-only confidentiality breach of GDPR-relevant personal data.

### Fix

Add record rules mirroring the sibling module `hr_employee_medical_examination`:
- normal users (`base.group_user`) only see the relatives of their own employee
  record (`[('employee_id.user_id', '=', user.id)]`);
- HR users (`hr.group_hr_user`) keep full access.

### Tests

Adds `test_hr_employee_relative_access.py`:
- a plain internal user cannot read another employee's relatives;
- a user still sees the relatives of their own employee record;
- an HR user retains full access.

### Affected versions

Same ACL and missing rule on **16.0, 17.0, 18.0, 19.0**. This PR targets 19.0;
I am happy to port it to the other branches.

