### PR TITLE
[18.0][IMP] hr_employee_calendar_planning: Fix test compatibility

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -187,10 +187,14 @@ class HrEmployee(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
+        test_condition = not config["test_enable"] or self.env.context.get(
+            "test_hr_employee_calendar_planning"
+        )
+        if not test_condition:
+            return res
         # Avoid creating an employee without calendars
         if (
             not self.env.context.get("skip_employee_calendars_required")
-            and not config["test_enable"]
             and not self.env.context.get("install_mode")
             and res.filtered(lambda x: not x.calendar_ids)
         ):

--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -4,6 +4,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools import config
 
 
 class ResourceCalendar(models.Model):
@@ -150,18 +151,20 @@ class ResourceCalendar(models.Model):
         on the dates specified by context.
         """
         res = super()._compute_hours_per_day()
-        for item in self.filtered(lambda x: x.auto_generate and x.flexible_hours):
-            from_date = self.env.context.get("flexible_hours_from_date")
-            to_date = self.env.context.get("flexible_hours_to_date")
-            employee = fields.first(item.employee_ids)
+        for item in self:
             hours = item.stored_hours_per_day
-            if (from_date or to_date) and employee:
-                calendars = employee._get_planning_calendars(from_date, to_date)
-                hours = (
-                    (sum(c.stored_hours_per_day for c in calendars.calendar_id))
-                    if calendars
-                    else False
-                )
+            if item.auto_generate and item.flexible_hours:
+                from_date = self.env.context.get("flexible_hours_from_date")
+                to_date = self.env.context.get("flexible_hours_to_date")
+                employee = fields.first(item.employee_ids)
+                hours = item.stored_hours_per_day
+                if (from_date or to_date) and employee:
+                    calendars = employee._get_planning_calendars(from_date, to_date)
+                    hours = (
+                        (sum(c.stored_hours_per_day for c in calendars.calendar_id))
+                        if calendars
+                        else False
+                    )
             item.hours_per_day = hours
         return res
 
@@ -206,6 +209,25 @@ class ResourceCalendar(models.Model):
                         total_items=total_items,
                     )
                 )
+
+    @api.model_create_multi
+    def create(self, vals):
+        test_condition = not config["test_enable"] or self.env.context.get(
+            "test_hr_employee_calendar_planning"
+        )
+        if not test_condition:
+            # If we are running a test from another module, the behavior must be
+            # maintained, we must simulate the definition of the stored* fields
+            for vals_item in vals:
+                for f_name in [
+                    "flexible_hours",
+                    "full_time_required_hours",
+                    "hours_per_day",
+                ]:
+                    if f_name in vals_item:
+                        vals_item[f"stored_{f_name}"] = vals_item[f_name]
+                        del vals_item[f_name]
+        return super().create(vals)
 
     def write(self, vals):
         res = super().write(vals)

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -20,6 +20,9 @@ class TestHrEmployeeCalendarPlanningCommon(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(
+            context=dict(cls.env.context, test_hr_employee_calendar_planning=True)
+        )
         resource_calendar = cls.env["resource.calendar"]
         cls.calendar1 = resource_calendar.create(
             {"name": "Test calendar 1", "attendance_ids": []}


### PR DESCRIPTION
Fix test compatibility

Install hr_employee_calendar_planning + test hr_holidays_leave_repeated

When hr_employee_calendar_planning is installed and tests for other modules that use resource_calendar_id are run, the tests will fail

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa