### PR TITLE
[18.0][FIX] hr_employee_calendar_planning: Prevent the creation of multiple calendars (2) when adding an employee

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -107,22 +107,18 @@ class HrEmployee(models.Model):
                     vals_list.append((0, 0, data))
         # Autogenerate
         if not self.resource_id.calendar_id.auto_generate:
-            self.resource_id.calendar_id = (
-                self.env["resource.calendar"]
-                .create(
-                    {
-                        "active": False,
-                        "company_id": self.company_id.id,
-                        "auto_generate": True,
-                        "name": _("Auto generated calendar for employee")
-                        + f" {self.name}",
-                        "attendance_ids": vals_list,
-                        "two_weeks_calendar": two_weeks,
-                        "tz": self.tz,  # take employee timezone as default
-                    }
-                )
-                .id
+            calendar = self.env["resource.calendar"].create(
+                {
+                    "active": False,
+                    "company_id": self.company_id.id,
+                    "auto_generate": True,
+                    "name": _("Auto generated calendar for employee") + f" {self.name}",
+                    "attendance_ids": vals_list,
+                    "two_weeks_calendar": two_weeks,
+                    "tz": self.tz,  # take employee timezone as default
+                }
             )
+            self.resource_calendar_id = self.resource_id.calendar_id = calendar
         else:
             self.resource_calendar_id.attendance_ids = vals_list
         # Set the hours per day to the last (top date end) calendar line to apply

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -509,6 +509,7 @@ class TestHrEmployeeCalendarPlanning(TestHrEmployeeCalendarPlanningCommon):
         with self.assertRaises(exceptions.ValidationError):
             self.calendar1.company_id = company2
 
+    @mute_logger("odoo.models.unlink")
     def test_employee_with_calendar_ids(self):
         employee = self.env["hr.employee"].create(
             {
@@ -559,14 +560,20 @@ class TestHrEmployeeCalendarPlanning(TestHrEmployeeCalendarPlanningCommon):
             self.employee.resource_calendar_id, employee2.resource_calendar_id
         )
 
+    @mute_logger("odoo.models.unlink")
     def test_user_action_create_employee(self):
         user = new_test_user(self.env, login="test-user")
+        calendar_model = self.env["resource.calendar"].with_context(active_test=False)
+        total_resources = calendar_model.search_count([])
         user.action_create_employee()
         self.assertIn(
             user.company_id.resource_calendar_id,
             user.employee_id.mapped("calendar_ids.calendar_id"),
         )
+        total_resources_now = calendar_model.search_count([])
+        self.assertEqual(total_resources_now - total_resources, 1)
 
+    @mute_logger("odoo.models.unlink")
     def test_create_employee_multi(self):
         employees = self.env["hr.employee"].create(
             [


### PR DESCRIPTION
Prevent the creation of multiple calendars (2) when adding an employee

Related to https://github.com/OCA/hr/pull/1612#pullrequestreview-5067067277

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa