### PR TITLE
[FIX]hr_employee_calendar_planning: make flexible_hours searchable(fi…

### DIFF
--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -45,11 +45,28 @@ class ResourceCalendar(models.Model):
     )
     flexible_hours = fields.Boolean(
         compute="_compute_flexible_hours",
+        search="_search_flexible_hours",
     )
     full_time_required_hours = fields.Float(
         compute="_compute_full_time_required_hours",
+        search="_search_full_time_required_hours",
     )
-    hours_per_day = fields.Float(store=False)
+    hours_per_day = fields.Float(store=False, search="_search_hours_per_day")
+
+    def _search_flexible_hours(self, operator, value):
+        """Search the persisted value used by the computed field.
+
+        ``flexible_hours`` can depend on the planning dates in the context, so
+        it cannot be stored. Domains still need to be able to use the field,
+        for example the domain on Helpdesk teams' working hours.
+        """
+        return [("stored_flexible_hours", operator, value)]
+
+    def _search_full_time_required_hours(self, operator, value):
+        return [("stored_full_time_required_hours", operator, value)]
+
+    def _search_hours_per_day(self, operator, value):
+        return [("stored_hours_per_day", operator, value)]
 
     @api.depends(
         "auto_generate",

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -441,6 +441,49 @@ class TestHrEmployeeCalendarPlanning(TestHrEmployeeCalendarPlanningCommon):
         )
         self.assertEqual(res_2020[self.employee.id][0][1], 4.0)
 
+    def test_search_flexible_hours(self):
+        self.calendar1.write(
+            {
+                "stored_flexible_hours": False,
+                "stored_full_time_required_hours": 40,
+                "stored_hours_per_day": 8,
+            }
+        )
+        self.calendar2.write(
+            {
+                "stored_flexible_hours": True,
+                "stored_full_time_required_hours": 20,
+                "stored_hours_per_day": 4,
+            }
+        )
+
+        calendars = self.env["resource.calendar"].search(
+            [
+                ("id", "in", (self.calendar1 | self.calendar2).ids),
+                ("flexible_hours", "=", False),
+            ]
+        )
+
+        self.assertEqual(calendars, self.calendar1)
+
+        calendars = self.env["resource.calendar"].search(
+            [
+                ("id", "in", (self.calendar1 | self.calendar2).ids),
+                ("full_time_required_hours", "=", 40),
+            ]
+        )
+
+        self.assertEqual(calendars, self.calendar1)
+
+        calendars = self.env["resource.calendar"].search(
+            [
+                ("id", "in", (self.calendar1 | self.calendar2).ids),
+                ("hours_per_day", "=", 8),
+            ]
+        )
+
+        self.assertEqual(calendars, self.calendar1)
+
     def test_post_install_hook(self):
         self.employee.resource_calendar_id = self.calendar1.id
         post_init_hook(self.env, self.employee)


### PR DESCRIPTION
### Problem

The `hr_employee_calendar_planning` module redefines
`resource.calendar.flexible_hours` as a non-stored computed field.

The Helpdesk module uses this field in the
`helpdesk.team.resource_calendar_id` domain:

```python
[
    ("flexible_hours", "=", False),
    ("attendance_ids", "!=", False),
]
```

When `helpdesk_holidays` is installed or loaded, Odoo validates this domain and
raises the following error:

> Unsearchable field “flexible_hours” in path “flexible_hours”

As a result, Odoo cannot load the database registry.

### Technical cause

The standard `flexible_hours` field is stored and can therefore be used in
domains.

However, `hr_employee_calendar_planning` needs to compute its value dynamically
from the context dates for automatically generated calendars. Therefore, the
field is redefined as non-stored:

```python
flexible_hours = fields.Boolean(
    compute="_compute_flexible_hours",
)
```

Non-stored computed fields must provide a search method to be used in domains.
Since no search method was defined, Odoo rejected the Helpdesk domain during
view validation.

### Proposed changes

Add the `_search_flexible_hours` method and delegate searches to the persisted
`stored_flexible_hours` field:

```python
def _search_flexible_hours(self, operator, value):
    return [("stored_flexible_hours", operator, value)]
```

The contextual computation of `flexible_hours` remains unchanged. This change
only makes the field searchable and restores compatibility with existing Odoo
domains.

### How to test

1. Install or upgrade `hr_employee_calendar_planning`.
2. Install `helpdesk_holidays`.
3. Verify that the database registry loads without a `ParseError`.
4. Open the Helpdesk team configuration and verify that the `Working Hours`
   field still filters out flexible calendars and calendars without attendances.
5. Run the following checks:

```bash
python -m compileall -q \
    hr_employee_calendar_planning/models/resource_calendar.py \
    hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py

ruff check \
    hr_employee_calendar_planning/models/resource_calendar.py \
    hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
```

A regression test was added to verify searches using
`flexible_hours = False`.

### Additional notes

This change does not modify Helpdesk or introduce a dependency between Helpdesk
and `hr_employee_calendar_planning`.

The fix is implemented in the module that redefines the field, making it
compatible with existing domains that use `flexible_hours`.

### Related PR
The compatibility changes that introduced this behavior were made in https://github.com/OCA/hr/pull/1601