### PR TITLE
[19.0][FIX] hr_employee_calendar_planning: Prevent the creation of multiple calendars (2) when adding an employee

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -69,6 +69,11 @@ class HrEmployee(models.Model):
 
     def _regenerate_calendar(self):
         self.ensure_one()
+        if not self.version_id:
+            # It is important that if there is no auto-generated version_id (from the
+            # create method of hr.employee.calendar), we do not regenerate the calendar
+            # "yet"; this will be done later in the create method of hr.employee.
+            return
         vals_list = []
         today = fields.Date.context_today(self)
         active_planning = self._get_planning_calendars(today, today)
@@ -112,22 +117,24 @@ class HrEmployee(models.Model):
                 seq += 1
                 vals_list.append((0, 0, data))
         if not self.resource_id.calendar_id.auto_generate:
-            self.resource_id.calendar_id = (
-                self.env["resource.calendar"]
-                .create(
-                    {
-                        "active": False,
-                        "company_id": self.company_id.id,
-                        "auto_generate": True,
-                        "name": self.env._("Auto generated calendar for employee")
-                        + f" {self.name}",
-                        "attendance_ids": vals_list,
-                        "two_weeks_calendar": two_weeks,
-                        "tz": self.tz,
-                    }
-                )
-                .id
+            calendar = self.env["resource.calendar"].create(
+                {
+                    "active": False,
+                    "company_id": self.company_id.id,
+                    "auto_generate": True,
+                    "name": self.env._("Auto generated calendar for employee")
+                    + f" {self.name}",
+                    "attendance_ids": vals_list,
+                    "two_weeks_calendar": two_weeks,
+                    "tz": self.tz,
+                }
             )
+            # We define only self.version_id.resource_calendar_id because the
+            # _inverse_resource_calendar_id() method in hr.version defines
+            # employee.resource_id.calendar_id
+            # We also don't need to define the employee's self.resource_calendar_id
+            # because it is a related version_id.resource_calendar_id
+            self.version_id.resource_calendar_id = calendar
         else:
             self.resource_calendar_id.attendance_ids = vals_list
         if planning_to_use:

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -413,6 +413,7 @@ class TestHrEmployeeCalendarPlanning(BaseCommon):
         with self.assertRaises(exceptions.ValidationError):
             self.calendar1.company_id = company2
 
+    @mute_logger("odoo.models.unlink")
     def test_employee_with_calendar_ids(self):
         employee = self.env["hr.employee"].create(
             {
@@ -522,12 +523,18 @@ class TestHrEmployeeCalendarPlanning(BaseCommon):
             with self.assertRaises(unittest.SkipTest):
                 self.test_employee_copy()
 
+    @mute_logger("odoo.models.unlink")
     def test_user_action_create_employee(self):
         user = new_test_user(self.env, login="test-user-cal")
+        calendar_model = self.env["resource.calendar"].with_context(active_test=False)
+        total_resources = calendar_model.search_count([])
         user.action_create_employee()
         self.assertTrue(user.employee_id)
         self.assertTrue(user.employee_id.calendar_ids)
+        total_resources_now = calendar_model.search_count([])
+        self.assertEqual(total_resources_now - total_resources, 1)
 
+    @mute_logger("odoo.models.unlink")
     def test_create_employee_multi(self):
         employees = self.env["hr.employee"].create(
             [


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/hr/pull/1614#issuecomment-5480775322

Prevent the creation of multiple calendars (2) when adding an employee

Related to https://github.com/OCA/hr/pull/1612#pullrequestreview-5067067277

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa