### PR TITLE
[19.0][IMP] hr_employee_calendar_planning: Add hours_per_week compatibility

### DIFF
--- a/hr_employee_calendar_planning/README.rst
+++ b/hr_employee_calendar_planning/README.rst
@@ -62,18 +62,18 @@ Configuration
 2. Open or create a new one.
 3. On the "Work Information" tab, fill the section "Working Hours" with:
 
-   - Starting date (optional).
-   - Ending date (optional).
-   - Working time to apply during that date interval.
+   -  Starting date (optional).
+   -  Ending date (optional).
+   -  Working time to apply during that date interval.
 
 Known issues / Roadmap
 ======================
 
-- Add a wizard for generating next year calendar planning based on
-  current one in batch.
-- Add constraint for avoiding planning lines overlapping.
-- Avoid the regeneration of whole private calendars each time a change
-  is detected.
+-  Add a wizard for generating next year calendar planning based on
+   current one in batch.
+-  Add constraint for avoiding planning lines overlapping.
+-  Avoid the regeneration of whole private calendars each time a change
+   is detected.
 
 Bug Tracker
 ===========
@@ -96,28 +96,28 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza
-  - Víctor Martínez
+   -  Pedro M. Baeza
+   -  Víctor Martínez
 
-- `Creu Blanca <https://www.creu-blanca.es/>`__:
+-  `Creu Blanca <https://www.creu-blanca.es/>`__:
 
-  - Jaime Arroyo
+   -  Jaime Arroyo
 
-- `ForgeFlow <https://www.forgeflow.com/>`__:
+-  `ForgeFlow <https://www.forgeflow.com/>`__:
 
-  - Jordi Ballester Alomar (jordi.ballester@forgeflow.com)
-  - Nattapong W. <aphon61bank@gmail.com>
+   -  Jordi Ballester Alomar (jordi.ballester@forgeflow.com)
+   -  Nattapong W. <aphon61bank@gmail.com>
 
-- `PeGon <https://www.pegon.ch>`__:
+-  `PeGon <https://www.pegon.ch>`__:
 
-  - Pedro Evaristo Gonzalez Sanchez <pedro.gonzalez@pegon.ch>
+   -  Pedro Evaristo Gonzalez Sanchez <pedro.gonzalez@pegon.ch>
 
-- ``Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>``\ \_
-- `Studio73 <https://www.studio73.es>`__:
+-  ``Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>``\ \_
+-  `Studio73 <https://www.studio73.es>`__:
 
-  - Vicent Castells Donat <vicent@studio73.es>
+   -  Vicent Castells Donat <vicent@studio73.es>
 
 Maintainers
 -----------

--- a/hr_employee_calendar_planning/__manifest__.py
+++ b/hr_employee_calendar_planning/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Employee Calendar Planning",
-    "version": "19.0.1.1.5",
+    "version": "19.0.1.2.0",
     "category": "Human Resources",
     "website": "https://github.com/OCA/hr",
     "author": "Tecnativa,Odoo Community Association (OCA)",

--- a/hr_employee_calendar_planning/hooks.py
+++ b/hr_employee_calendar_planning/hooks.py
@@ -24,10 +24,17 @@ def pre_init_hook(env):
     )
     env.cr.execute(
         """
+        ALTER TABLE resource_calendar
+        ADD COLUMN IF NOT EXISTS stored_hours_per_week double precision
+        """,
+    )
+    env.cr.execute(
+        """
         UPDATE resource_calendar
         SET stored_flexible_hours = flexible_hours,
             stored_full_time_required_hours = full_time_required_hours,
-            stored_hours_per_day = hours_per_day
+            stored_hours_per_day = hours_per_day,
+            stored_hours_per_week = hours_per_week
         """,
     )
 

--- a/hr_employee_calendar_planning/migrations/19.0.1.2.0/pre-migration.py
+++ b/hr_employee_calendar_planning/migrations/19.0.1.2.0/pre-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+from odoo.addons.hr_employee_calendar_planning.hooks import pre_init_hook
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    pre_init_hook(env)

--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -237,13 +237,14 @@ class HrEmployee(models.Model):
         override this method to add the specific condition for that test.
         Example:
         condition = super()._test_module_hr_attendance_employee_calendar_planning()
-        return condition or (
+        condition_extra = not modules.module.current_test or (
             modules.module.current_test
             and modules.module.current_test.test_module
             == "hr_attendance_employee_calendar_planning"
         )
+        return condition or condition_extra
         """
-        return (
+        return not modules.module.current_test or (
             modules.module.current_test
             and modules.module.current_test.test_module
             == "hr_employee_calendar_planning"

--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -58,6 +58,8 @@ class HrEmployee(models.Model):
     def default_get(self, fields):
         """Set calendar_ids default value to cover all use cases."""
         vals = super().default_get(fields)
+        if not self._test_module_hr_attendance_employee_calendar_planning():
+            return vals
         if "calendar_ids" in fields and not vals.get("calendar_ids"):
             vals["calendar_ids"] = [
                 Command.create(

--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -25,6 +25,7 @@ class ResourceCalendar(models.Model):
     # - stored_full_time_required_hours: This field will behave the same as the
     # full_time_required_hours field
     # - stored_hours_per_day: This will behave the same as the hours_per_day field
+    # - stored_hours_per_week: This will behave the same as the hours_per_week field
     # The flexible_hour and full_time_required_hours fields are converted to compute
     # fields with store=False to ensure the correct stored_* field is used, except
     # when the calendar is auto_generated and dates are passed via context; in that
@@ -48,11 +49,17 @@ class ResourceCalendar(models.Model):
         readonly=False,
         help="Average hours per day a resource is supposed to work with this calendar.",
     )
+    stored_hours_per_week = fields.Float(
+        compute="_compute_stored_hours_per_week",
+        store=True,
+        readonly=False,
+    )
     # We set the field to store=False; we want it to be computed whenever that data
     # needs to be accessed.
     flexible_hours = fields.Boolean(store=False)
     full_time_required_hours = fields.Float(store=False)
     hours_per_day = fields.Float(store=False)
+    hours_per_week = fields.Float(store=False)
 
     @api.depends("schedule_type")
     def _compute_stored_flexible_hours(self):
@@ -152,6 +159,22 @@ class ResourceCalendar(models.Model):
             )
 
     @api.depends(
+        "attendance_ids",
+        "attendance_ids.hour_from",
+        "attendance_ids.hour_to",
+        "two_weeks_calendar",
+        "flexible_hours",
+    )
+    def _compute_stored_hours_per_week(self):
+        """This method is the same as _compute_hours_per_week() in the resource
+        module.
+        """
+        for calendar in self.filtered(lambda c: not c.flexible_hours):
+            calendar.stored_hours_per_week = float_round(
+                calendar._get_hours_per_week(), precision_digits=2
+            )
+
+    @api.depends(
         "auto_generate",
         "flexible_hours",
         "employee_ids.calendar_ids",
@@ -183,6 +206,35 @@ class ResourceCalendar(models.Model):
                         else False
                     )
             item.hours_per_day = hours
+        return res
+
+    @api.depends(
+        "auto_generate",
+        "flexible_hours",
+        "employee_ids.calendar_ids",
+        "employee_ids.calendar_ids.calendar_id.stored_flexible_hours",
+        "employee_ids.calendar_ids.calendar_id.stored_hours_per_week",
+    )
+    @api.depends_context(
+        "flexible_hours_from_date",
+        "flexible_hours_to_date",
+    )
+    def _compute_hours_per_week(self):
+        res = super()._compute_hours_per_week()
+        for item in self:
+            hours = item.stored_hours_per_week
+            if item.auto_generate and item.flexible_hours:
+                from_date = self.env.context.get("flexible_hours_from_date")
+                to_date = self.env.context.get("flexible_hours_to_date")
+                employee = item.employee_ids[:1]
+                if (from_date or to_date) and employee:
+                    calendars = employee._get_planning_calendars(from_date, to_date)
+                    hours = (
+                        (sum(c.stored_hours_per_week for c in calendars.calendar_id))
+                        if calendars
+                        else False
+                    )
+            item.hours_per_week = hours
         return res
 
     @api.constrains("active")
@@ -247,6 +299,7 @@ class ResourceCalendar(models.Model):
                     "flexible_hours",
                     "full_time_required_hours",
                     "hours_per_day",
+                    "hours_per_week",
                 ]:
                     if f_name in vals_item:
                         vals_item[f"stored_{f_name}"] = vals_item[f_name]

--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -4,7 +4,7 @@
 
 from odoo import api, fields, models, modules
 from odoo.exceptions import ValidationError
-from odoo.tools.float_utils import float_round
+from odoo.tools.float_utils import float_compare, float_round
 
 
 class ResourceCalendar(models.Model):
@@ -60,6 +60,30 @@ class ResourceCalendar(models.Model):
     full_time_required_hours = fields.Float(store=False)
     hours_per_day = fields.Float(store=False)
     hours_per_week = fields.Float(store=False)
+
+    @api.depends("stored_hours_per_week", "stored_full_time_required_hours")
+    def _compute_work_time_rate(self):
+        # Same behavior as _compute_work_time_rate() method but with stored fields.
+        _res = super()._compute_work_time_rate()
+        for calendar in self:
+            if calendar.stored_full_time_required_hours:
+                calendar.work_time_rate = (
+                    calendar.stored_hours_per_week
+                    / calendar.stored_full_time_required_hours
+                    * 100
+                )
+            else:
+                calendar.work_time_rate = 100
+
+            calendar.is_fulltime = (
+                float_compare(
+                    calendar.stored_full_time_required_hours,
+                    calendar.stored_hours_per_week,
+                    3,
+                )
+                == 0
+            )
+        return _res
 
     @api.depends("schedule_type")
     def _compute_stored_flexible_hours(self):
@@ -132,14 +156,16 @@ class ResourceCalendar(models.Model):
                     )
             item.full_time_required_hours = hours
 
-    @api.depends("hours_per_week", "company_id.resource_calendar_id.hours_per_week")
+    @api.depends(
+        "stored_hours_per_week", "company_id.resource_calendar_id.stored_hours_per_week"
+    )
     def _compute_stored_full_time_required_hours(self):
         """This method is the same as _compute_full_time_required_hours()
         in the resource module.
         """
         for calendar in self.filtered("company_id"):
             calendar.stored_full_time_required_hours = (
-                calendar.company_id.resource_calendar_id.hours_per_week
+                calendar.company_id.resource_calendar_id.stored_hours_per_week
             )
 
     @api.depends(

--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -283,7 +283,7 @@ class ResourceCalendar(models.Model):
 
     def _test_module_hr_attendance_employee_calendar_planning(self):
         """Similar to what was explained in the hr.employee method itself."""
-        return (
+        return not modules.module.current_test or (
             modules.module.current_test
             and modules.module.current_test.test_module
             == "hr_employee_calendar_planning"

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -223,6 +223,7 @@ class TestHrEmployeeCalendarPlanning(BaseCommon):
             {
                 "schedule_type": "flexible",
                 "stored_hours_per_day": 8,
+                "stored_hours_per_week": 40,
             }
         )
         self.calendar1.stored_full_time_required_hours = 40
@@ -231,6 +232,7 @@ class TestHrEmployeeCalendarPlanning(BaseCommon):
             {
                 "schedule_type": "flexible",
                 "stored_hours_per_day": 4,
+                "stored_hours_per_week": 20,
             }
         )
         self.calendar2.stored_full_time_required_hours = 20

--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -19,7 +19,7 @@ from odoo.addons.base.tests.common import BaseCommon
 from ..hooks import post_init_hook
 
 
-class TestHrEmployeeCalendarPlanning(BaseCommon):
+class TestHrEmployeeCalendarPlanningCommon(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -142,6 +142,8 @@ class TestHrEmployeeCalendarPlanning(BaseCommon):
                 ),
             ]
 
+
+class TestHrEmployeeCalendarPlanning(TestHrEmployeeCalendarPlanningCommon):
     @mute_logger("odoo.models.unlink")
     def test_calendar_planning(self):
         today = fields.Date.context_today(self)

--- a/hr_employee_calendar_planning/views/resource_calendar_views.xml
+++ b/hr_employee_calendar_planning/views/resource_calendar_views.xml
@@ -13,22 +13,30 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath
+                expr="(//label[@for='full_time_required_hours'])[1]"
+                position="after"
+            >
+                <label
+                    for="stored_full_time_required_hours"
+                    invisible="not company_id"
+                />
+            </xpath>
+            <xpath
                 expr="(//label[@for='full_time_required_hours'])[2]"
                 position="attributes"
             >
                 <attribute name="invisible">1</attribute>
             </xpath>
-            <label for="full_time_required_hours" position="after">
+            <xpath
+                expr="(//label[@for='full_time_required_hours'])[2]"
+                position="after"
+            >
                 <label
                     for="stored_full_time_required_hours"
-                    invisible="stored_flexible_hours"
+                    string="Required Full Time"
+                    invisible="company_id"
                 />
-                <label
-                    for="stored_full_time_required_hours"
-                    string="Full Time Equivalent"
-                    invisible="not stored_flexible_hours"
-                />
-            </label>
+            </xpath>
             <field name="full_time_required_hours" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
@@ -41,6 +49,12 @@
                     string="Full Time Equivalent"
                 />
             </field>
+            <xpath expr="(//label[@for='hours_per_day'])[1]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_day'])[1]" position="after">
+                <label for="stored_hours_per_day" string="Avg" />
+            </xpath>
             <xpath expr="(//field[@name='hours_per_day'])[1]" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
@@ -52,6 +66,12 @@
                     widget="float_time"
                     readonly="not stored_flexible_hours or auto_generate"
                 />
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_day'])[2]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_day'])[2]" position="after">
+                <label for="stored_hours_per_day" string="Avg" />
             </xpath>
             <xpath expr="(//field[@name='hours_per_day'])[2]" position="attributes">
                 <attribute name="invisible">1</attribute>
@@ -65,6 +85,12 @@
                     readonly="1"
                 />
             </xpath>
+            <xpath expr="(//label[@for='hours_per_day'])[3]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_day'])[3]" position="after">
+                <label for="stored_hours_per_day" string="Avg" />
+            </xpath>
             <xpath expr="(//field[@name='hours_per_day'])[3]" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
@@ -76,6 +102,12 @@
                     widget="float_time"
                     readonly="1"
                 />
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_day'])[4]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_day'])[4]" position="after">
+                <label for="stored_hours_per_day" string="Avg" />
             </xpath>
             <xpath expr="(//field[@name='hours_per_day'])[4]" position="attributes">
                 <attribute name="invisible">1</attribute>

--- a/hr_employee_calendar_planning/views/resource_calendar_views.xml
+++ b/hr_employee_calendar_planning/views/resource_calendar_views.xml
@@ -89,6 +89,84 @@
                     readonly="1"
                 />
             </xpath>
+            <xpath expr="(//label[@for='hours_per_week'])[1]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_week'])[1]" position="after">
+                <label for="stored_hours_per_week" string="Total" />
+            </xpath>
+            <xpath expr="(//field[@name='hours_per_week'])[1]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//field[@name='hours_per_week'])[1]" position="after">
+                <field
+                    name="stored_hours_per_week"
+                    nolabel="1"
+                    style="width: 6ch;"
+                    widget="float_time"
+                    readonly="not stored_flexible_hours or auto_generate"
+                />
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_week'])[2]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_week'])[2]" position="after">
+                <label for="stored_hours_per_week" string="Total" />
+            </xpath>
+            <xpath expr="(//field[@name='hours_per_week'])[2]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//field[@name='hours_per_week'])[2]" position="after">
+                <field
+                    name="stored_hours_per_week"
+                    nolabel="1"
+                    style="width: 6ch;"
+                    widget="float_time"
+                    readonly="1"
+                />
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_week'])[3]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_week'])[3]" position="after">
+                <label for="stored_hours_per_week" string="Total" />
+            </xpath>
+            <xpath expr="(//field[@name='hours_per_week'])[3]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//field[@name='hours_per_week'])[3]" position="after">
+                <field
+                    name="hours_per_week"
+                    nolabel="1"
+                    style="width: 6ch;"
+                    widget="float_time"
+                />
+                <field
+                    name="stored_hours_per_week"
+                    nolabel="1"
+                    style="width: 6ch;"
+                    widget="float_time"
+                    readonly="1"
+                />
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_week'])[4]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//label[@for='hours_per_week'])[4]" position="after">
+                <label for="stored_hours_per_week" string="Total" />
+            </xpath>
+            <xpath expr="(//field[@name='hours_per_week'])[4]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="(//field[@name='hours_per_week'])[4]" position="after">
+                <field
+                    name="stored_hours_per_week"
+                    nolabel="1"
+                    style="width: 6ch;"
+                    widget="float_time"
+                    readonly="1"
+                />
+            </xpath>
             <xpath expr="//page[@name='working_hours']" position="attributes">
                 <attribute
                     name="invisible"


### PR DESCRIPTION
Change done:
- [x] Add `hours_per_week` compatibility
- [x] Define the appropriate condition in `_test_module_hr_attendance_employee_calendar_planning()`
- [x] FWP from 18.0: https://github.com/OCA/hr/pull/1621
- [x] Define the appropriate labels in the calendar form view
- [x] Define the correct behavior of `_compute_work_time_rate()`

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa