### PR TITLE
[19.0][IMP] hr_employee_calendar_planning: Test compatibility with dependent modules

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -228,14 +228,31 @@ class HrEmployee(models.Model):
         new.filtered("calendar_ids").regenerate_calendar()
         return new
 
+    def _test_module_hr_attendance_employee_calendar_planning(self):
+        """This method indicates whether the module currently being executed is the
+        one of interest for performing various actions.
+        Generally, only the `hr_employee_calendar_planning` module will be checked,
+        but if, for example, there is another module that depends on it (such as
+        `hr_attendance_employee_calendar_planning`), that other module will need to
+        override this method to add the specific condition for that test.
+        Example:
+        condition = super()._test_module_hr_attendance_employee_calendar_planning()
+        return condition or (
+            modules.module.current_test
+            and modules.module.current_test.test_module
+            == "hr_attendance_employee_calendar_planning"
+        )
+        """
+        return (
+            modules.module.current_test
+            and modules.module.current_test.test_module
+            == "hr_employee_calendar_planning"
+        )
+
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
-        if (
-            modules.module.current_test
-            and not modules.module.current_test.test_module
-            == "hr_employee_calendar_planning"
-        ):
+        if not self._test_module_hr_attendance_employee_calendar_planning():
             return res
         # Avoid creating an employee without calendars
         if (

--- a/hr_employee_calendar_planning/models/resource_calendar.py
+++ b/hr_employee_calendar_planning/models/resource_calendar.py
@@ -229,13 +229,17 @@ class ResourceCalendar(models.Model):
                     )
                 )
 
+    def _test_module_hr_attendance_employee_calendar_planning(self):
+        """Similar to what was explained in the hr.employee method itself."""
+        return (
+            modules.module.current_test
+            and modules.module.current_test.test_module
+            == "hr_employee_calendar_planning"
+        )
+
     @api.model_create_multi
     def create(self, vals):
-        if (
-            modules.module.current_test
-            and not modules.module.current_test.test_module
-            == "hr_employee_calendar_planning"
-        ):
+        if not self._test_module_hr_attendance_employee_calendar_planning():
             # If we are running a test from another module, the behavior must be
             # maintained, we must simulate the definition of the stored* fields
             for vals_item in vals:


### PR DESCRIPTION
Test compatibility with dependent modules

Related to https://github.com/OCA/hr/pull/1619

It is important to include a method to verify whether the tests for module x are running, because there will be cases (such as `hr_attendance_employee_calendar_planning`) where the tests for that module —which depends on this one (`hr_employee_calendar_planning`)— also need to satisfy the condition.

**Note**: Something similar will happen with the `hr_holidays_calendar_planning` module

Please @pedrobaeza can you review it?

@Tecnativa