### PR TITLE
[18.0][IMP] hr_employee_calendar_planning: Avoiding side effects when creating an employee

### DIFF
--- a/hr_employee_calendar_planning/models/hr_employee.py
+++ b/hr_employee_calendar_planning/models/hr_employee.py
@@ -62,6 +62,11 @@ class HrEmployee(models.Model):
     def default_get(self, fields):
         """Set calendar_ids default value to cover all use cases."""
         vals = super().default_get(fields)
+        test_condition = not config["test_enable"] or self.env.context.get(
+            "test_hr_employee_calendar_planning"
+        )
+        if not test_condition:
+            return vals
         if "calendar_ids" in fields and not vals.get("calendar_ids"):
             vals["calendar_ids"] = [
                 (0, 0, {"calendar_id": self.env.company.resource_calendar_id.id}),


### PR DESCRIPTION
Avoiding side effects when creating an employee

If `hr_employee_calendar_planning` is installed and, for example, the tests for hr_holidays_leave_repeated are run, they should not fail.

Related to https://github.com/OCA/hr/pull/1611

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa