### PR TITLE
[19.0][FIX] hr_employee_calendar_planning: Preventing an error in the tests if hr_holidays is installed

### DIFF
--- a/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
+++ b/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py
@@ -88,8 +88,8 @@ class TestHrEmployeeCalendarPlanningCommon(BaseCommon):
             {
                 "name": "Global Leave 2",
                 "calendar_id": cls.calendar1.id,
-                "date_from": now,  # Justo ahora
-                "date_to": now + relativedelta(hours=4),
+                "date_from": now + relativedelta(days=1),
+                "date_to": now + relativedelta(days=2),
             }
         )
         cls.global_leave3 = cls.env["resource.calendar.leaves"].create(


### PR DESCRIPTION
Preventing an error in the tests if hr_holidays is installed

If `hr_holidays` is installed and the hr_employee_calendar_planning tests are run, this error occurs

```
ERROR prod odoo.addons.hr_employee_calendar_planning.tests.test_hr_employee_calendar_planning: ERROR: TestHrEmployeeCalendarPlanning.test_post_install_hook Traceback (most recent call last):
  File "/opt/odoo/auto/addons/hr_employee_calendar_planning/tests/test_hr_employee_calendar_planning.py", line 314, in test_post_install_hook
    self.global_leave1.date_from = self.employee.create_date.date()

  File "/opt/odoo/auto/addons/hr_holidays/models/resource.py", line 37, in _check_compare_dates
    raise ValidationError(_('Two public holidays cannot overlap each other for the same working hours.'))
odoo.exceptions.ValidationError: Two public holidays cannot overlap each other for the same working hours.
```

The problem was related to the dates in `global_leave2`

Please @carlos-lopez-tecnativa can you review it?

@Tecnativa